### PR TITLE
Remove config from eval.

### DIFF
--- a/client.go
+++ b/client.go
@@ -215,7 +215,7 @@ func (c *Client) Tracer(name string, opts ...oteltrace.TracerOption) oteltrace.T
 //	    Scorers:    scorers,
 //	})
 func NewEvaluator[I, R any](client *Client) *eval.Evaluator[I, R] {
-	return eval.NewEvaluator[I, R](client.session, client.config, client.tracerProvider, client.API())
+	return eval.NewEvaluator[I, R](client.session, client.tracerProvider, client.API(), client.config.DefaultProjectName)
 }
 
 // API returns an API client for making direct calls to the Braintrust API.

--- a/eval/eval_integration_test.go
+++ b/eval/eval_integration_test.go
@@ -123,7 +123,7 @@ func TestEval_Integration(t *testing.T) {
 	defer func() { _ = tp.Shutdown(ctx) }()
 
 	// Create evaluator with VCR-wrapped API client
-	evaluator := NewEvaluator[string, string](session, cfg, tp, apiClient)
+	evaluator := NewEvaluator[string, string](session, tp, apiClient, cfg.DefaultProjectName)
 	result, err := evaluator.Run(ctx, Opts[string, string]{
 		Experiment: "test-experiment",
 		Dataset:    cases,
@@ -247,7 +247,7 @@ func TestEval_Integration_StringToStruct(t *testing.T) {
 	defer func() { _ = tp.Shutdown(ctx) }()
 
 	// Run the evaluation - this should handle string-to-struct conversion
-	evaluator := NewEvaluator[QuestionInput, AnswerOutput](session, cfg, tp, apiClient)
+	evaluator := NewEvaluator[QuestionInput, AnswerOutput](session, tp, apiClient, cfg.DefaultProjectName)
 	result, err := evaluator.Run(ctx, Opts[QuestionInput, AnswerOutput]{
 		Experiment: "test-experiment",
 		Dataset:    cases,
@@ -303,7 +303,7 @@ func TestEval_Integration_DatasetByID(t *testing.T) {
 	defer func() { _ = tp.Shutdown(ctx) }()
 
 	// Run evaluation
-	evaluator := NewEvaluator[int, int](session, cfg, tp, apiClient)
+	evaluator := NewEvaluator[int, int](session, tp, apiClient, cfg.DefaultProjectName)
 	result, err := evaluator.Run(ctx, Opts[int, int]{
 		Experiment: "test-experiment",
 		Dataset:    cases,
@@ -368,7 +368,7 @@ func TestEval_Integration_DatasetByName(t *testing.T) {
 	defer func() { _ = tp.Shutdown(ctx) }()
 
 	// Run evaluation
-	evaluator := NewEvaluator[int, int](session, cfg, tp, apiClient)
+	evaluator := NewEvaluator[int, int](session, tp, apiClient, cfg.DefaultProjectName)
 	result, err := evaluator.Run(ctx, Opts[int, int]{
 		Experiment: "test-experiment",
 		Dataset:    cases,
@@ -439,7 +439,7 @@ func TestEval_Integration_DatasetWithTagsAndMetadata(t *testing.T) {
 	defer func() { _ = tp.Shutdown(ctx) }()
 
 	// Run evaluation - tags and metadata should be preserved
-	evaluator := NewEvaluator[int, int](session, cfg, tp, apiClient)
+	evaluator := NewEvaluator[int, int](session, tp, apiClient, cfg.DefaultProjectName)
 	result, err := evaluator.Run(ctx, Opts[int, int]{
 		Experiment: "test-experiment",
 		Dataset:    cases,
@@ -482,7 +482,7 @@ func TestEval_Integration_ExperimentTags(t *testing.T) {
 	defer func() { _ = tp.Shutdown(ctx) }()
 
 	// Run eval with experiment-level tags
-	evaluator := NewEvaluator[string, string](session, cfg, tp, apiClient)
+	evaluator := NewEvaluator[string, string](session, tp, apiClient, cfg.DefaultProjectName)
 	result, err := evaluator.Run(ctx, Opts[string, string]{
 		Experiment: "test-experiment",
 		Dataset:    cases,
@@ -520,7 +520,7 @@ func TestEval_Integration_ExperimentMetadata(t *testing.T) {
 	defer func() { _ = tp.Shutdown(ctx) }()
 
 	// Run eval with experiment-level metadata
-	evaluator := NewEvaluator[string, string](session, cfg, tp, apiClient)
+	evaluator := NewEvaluator[string, string](session, tp, apiClient, cfg.DefaultProjectName)
 	result, err := evaluator.Run(ctx, Opts[string, string]{
 		Experiment: "test-experiment",
 		Dataset:    cases,
@@ -569,7 +569,7 @@ func TestEval_Integration_UpdateFlag(t *testing.T) {
 	})
 
 	// Create evaluator for all runs
-	evaluator := NewEvaluator[string, string](session, cfg, tp, apiClient)
+	evaluator := NewEvaluator[string, string](session, tp, apiClient, cfg.DefaultProjectName)
 
 	// First run: Create new experiment (Update: false)
 	result1, err := evaluator.Run(ctx, Opts[string, string]{
@@ -665,7 +665,7 @@ func TestEval_ProjectNameFallback(t *testing.T) {
 	})
 
 	// Run eval WITHOUT specifying ProjectName (should use cfg.DefaultProjectName)
-	evaluator := NewEvaluator[string, string](session, cfg, tp, apiClient)
+	evaluator := NewEvaluator[string, string](session, tp, apiClient, cfg.DefaultProjectName)
 	result, err := evaluator.Run(ctx, Opts[string, string]{
 		Experiment: "test-experiment",
 		// ProjectName not specified - should fall back to cfg.DefaultProjectName
@@ -711,7 +711,7 @@ func TestEval_NoProjectName(t *testing.T) {
 	})
 
 	// Run eval WITHOUT specifying ProjectName and NO config default (should fail)
-	evaluator := NewEvaluator[string, string](session, cfg, tp, apiClient)
+	evaluator := NewEvaluator[string, string](session, tp, apiClient, cfg.DefaultProjectName)
 	result, err := evaluator.Run(ctx, Opts[string, string]{
 		Experiment: "test-experiment",
 		// ProjectName not specified AND cfg.DefaultProjectName is empty

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -11,7 +11,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 
-	"github.com/braintrustdata/braintrust-sdk-go/config"
 	"github.com/braintrustdata/braintrust-sdk-go/internal/oteltest"
 	"github.com/braintrustdata/braintrust-sdk-go/internal/tests"
 	"github.com/braintrustdata/braintrust-sdk-go/trace"
@@ -43,16 +42,8 @@ func newUnitTestEval[I, R any](t *testing.T, dataset Dataset[I, R], task TaskFun
 	// Create fake session with test data
 	session := tests.NewSession(t)
 
-	// Create test config
-	cfg := &config.Config{
-		AppURL:             "https://test.braintrust.dev",
-		OrgName:            "test-org",
-		DefaultProjectName: "test-project",
-	}
-
 	// Create eval with fake IDs
 	e := testNewEval(
-		cfg,
 		session,
 		tracer,
 		"exp-12345678",    // fake experiment ID

--- a/eval/functions_integration_test.go
+++ b/eval/functions_integration_test.go
@@ -521,7 +521,7 @@ func TestFunctionsAPI_EndToEnd_MixedTypes(t *testing.T) {
 	defer func() { _ = tp.Shutdown(ctx) }()
 
 	// Create evaluator with VCR-wrapped API client
-	evaluator := NewEvaluator[QuestionInput, AnswerOutput](session, cfg, tp, apiClient)
+	evaluator := NewEvaluator[QuestionInput, AnswerOutput](session, tp, apiClient, cfg.DefaultProjectName)
 	// Use fixed experiment name for VCR determinism
 	result, err := evaluator.Run(ctx, Opts[QuestionInput, AnswerOutput]{
 		Experiment: "test-e2e-exp",


### PR DESCRIPTION
All of the things it needed (orgName, ete) are owned by the session.