### PR TITLE
Add time to first token for OpenAI Chat Completions

### DIFF
--- a/trace/contrib/github.com/sashabaranov/go-openai/traceopenai_test.go
+++ b/trace/contrib/github.com/sashabaranov/go-openai/traceopenai_test.go
@@ -77,7 +77,7 @@ func TestChatCompletions(t *testing.T) {
 
 	// Validate span basics
 	ts.AssertInTimeRange(timeRange)
-	ts.AssertNameIs("openai.chat.completions.create")
+	ts.AssertNameIs("Chat Completion")
 
 	// Check metadata contains expected fields
 	metadata := ts.Metadata()
@@ -127,7 +127,7 @@ func TestWrapClient(t *testing.T) {
 
 	// Validate span
 	ts.AssertInTimeRange(timeRange)
-	ts.AssertNameIs("openai.chat.completions.create")
+	ts.AssertNameIs("Chat Completion")
 
 	// Check metadata
 	metadata := ts.Metadata()
@@ -194,7 +194,7 @@ func TestStreamingChatCompletions(t *testing.T) {
 
 	// Validate span
 	ts.AssertInTimeRange(timeRange)
-	ts.AssertNameIs("openai.chat.completions.create")
+	ts.AssertNameIs("Chat Completion")
 
 	// Check metadata indicates streaming
 	metadata := ts.Metadata()
@@ -256,7 +256,7 @@ func TestErrorHandling(t *testing.T) {
 
 	// Validate span
 	ts.AssertInTimeRange(timeRange)
-	ts.AssertNameIs("openai.chat.completions.create")
+	ts.AssertNameIs("Chat Completion")
 
 	// Check metadata
 	metadata := ts.Metadata()

--- a/trace/contrib/openai/chatcompletions_test.go
+++ b/trace/contrib/openai/chatcompletions_test.go
@@ -64,7 +64,7 @@ func TestOpenAIChatCompletions(t *testing.T) {
 	assertChatSpanValid(t, ts, timeRange)
 
 	// Check that the span name is correct
-	assert.Equal("openai.chat.completions.create", ts.Name())
+	assert.Equal("Chat Completion", ts.Name())
 
 	// Check input field
 	inputRaw := ts.Input()
@@ -167,7 +167,7 @@ func TestOpenAIChatCompletionsStreaming(t *testing.T) {
 	assertChatSpanValid(t, ts, timeRange)
 
 	// Check that the span name is correct
-	assert.Equal("openai.chat.completions.create", ts.Name())
+	assert.Equal("Chat Completion", ts.Name())
 
 	// Check input field
 	inputRaw := ts.Input()
@@ -404,7 +404,7 @@ func TestOpenAIChatCompletionsStreamingToolCalls(t *testing.T) {
 	assertChatSpanValid(t, ts, timeRange)
 
 	// Check that the span name is correct
-	assert.Equal("openai.chat.completions.create", ts.Name())
+	assert.Equal("Chat Completion", ts.Name())
 
 	// Check output field - should be properly structured
 	output := ts.Output()
@@ -751,7 +751,7 @@ func TestChatCompletionsStructuredAssertions(t *testing.T) {
 	// Assert the entire structure at once
 	AssertMatchesObject(t, spanData, map[string]interface{}{
 		"span_attributes": map[string]interface{}{
-			"name": "openai.chat.completions.create",
+			"name": "Chat Completion",
 			"type": "llm",
 		},
 		"input": []interface{}{
@@ -840,7 +840,7 @@ func TestToolCallsStructuredAssertions(t *testing.T) {
 	// Assert the entire tool calls structure at once
 	AssertMatchesObject(t, spanData, map[string]interface{}{
 		"span_attributes": map[string]interface{}{
-			"name": "openai.chat.completions.create",
+			"name": "Chat Completion",
 			"type": "llm",
 		},
 		"input": []interface{}{
@@ -1072,7 +1072,7 @@ func assertChatSpanValid(t *testing.T, span oteltest.Span, timeRange oteltest.Ti
 	assert := assert.New(t)
 
 	span.AssertInTimeRange(timeRange)
-	span.AssertNameIs("openai.chat.completions.create")
+	span.AssertNameIs("Chat Completion")
 	assert.Equal(codes.Unset, span.Status().Code)
 
 	metadata := span.Metadata()
@@ -1089,6 +1089,7 @@ func assertChatSpanValid(t *testing.T, span oteltest.Span, timeRange oteltest.Ti
 		"prompt_tokens":                         gtz,
 		"completion_tokens":                     gtz,
 		"tokens":                                gtz,
+		"time_to_first_token":                   gtez,
 		"prompt_cached_tokens":                  gtez,
 		"completion_cached_tokens":              gtez,
 		"completion_reasoning_tokens":           gtez,

--- a/trace/contrib/openai/traceopenai_test.go
+++ b/trace/contrib/openai/traceopenai_test.go
@@ -334,6 +334,7 @@ func assertSpanValid(t *testing.T, span oteltest.Span, timeRange oteltest.TimeRa
 		"prompt_tokens":                         gtz,
 		"completion_tokens":                     gtz,
 		"tokens":                                gtz,
+		"time_to_first_token":                   gtez,
 		"prompt_cached_tokens":                  gtez,
 		"completion_cached_tokens":              gtez,
 		"completion_reasoning_tokens":           gtez,


### PR DESCRIPTION
- add time to first token to openai chat completions
- rename chat completions span `openai.chat.completions.create` -> `Chat Completion` (to match Python & TS SDKs)