### PR TITLE
set proper BRAINTRUST_API_URL when doing VCR replay

### DIFF
--- a/eval/task_api_test.go
+++ b/eval/task_api_test.go
@@ -183,7 +183,7 @@ func setupIntegrationTest(t *testing.T) (*auth.Session, *api.API) {
 
 	ctx := context.Background()
 	session, err := auth.NewSession(ctx, auth.Options{
-		APIKey: vcr.GetAPIKeyForVCR(t),
+		APIKey: httpsClient.APIKey(),
 		AppURL: "https://www.braintrust.dev",
 		Logger: logger.Discard(),
 		Client: httpsClient,


### PR DESCRIPTION
VCR replay requires api url to be `api.braintrust.dev`