### PR TITLE
publish go release from github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+# This workflow is triggered when a new tag is pushed to main.
+# It can also be run manually to re-publish a release in case it failed for some reason.
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g., v1.0.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+# NOTE: we pin specific versions below so the publish is reproducible.
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5.5.0
+        with:
+          go-version: 1.23.0
+
+      - name: Install goreleaser
+        run: |
+          wget -q https://github.com/goreleaser/goreleaser/releases/download/v2.12.7/goreleaser_Linux_x86_64.tar.gz
+          tar -xzf goreleaser_Linux_x86_64.tar.gz goreleaser
+          sudo mv goreleaser /usr/local/bin/
+          goreleaser --version
+
+      - name: Publish release
+        run: make release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # these envars are needed because `make release` runs CI as a final sanity check
+          CGO_ENABLED: 0
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help ci build clean test test-quiet test-vcr-off test-vcr-record test-vcr-verify cover cover-path lint fmt mod-verify fix godoc examples
+.PHONY: help ci build clean test test-quiet test-vcr-off test-vcr-record test-vcr-verify cover cover-path lint fmt mod-verify fix godoc examples release
 
 help:
 	@echo "Available commands:"
@@ -19,6 +19,7 @@ help:
 	@echo "  examples         - Run all examples"
 	@echo "  ci               - Run CI pipeline (clean, lint, test, build)"
 	@echo "  precommit        - Run fmt then ci"
+	@echo "  release          - Publish release with goreleaser"
 
 ci: clean lint mod-verify test build
 
@@ -76,3 +77,6 @@ examples:
 	@echo "All examples completed!"
 
 precommit: fmt ci
+
+release: ci
+	./scripts/publish.sh

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Check if working directory is clean
+if ! git diff-index --quiet HEAD --; then
+    echo "Error: Working directory is not clean." >&2
+    git status --porcelain
+    exit 1
+fi
+
+# Check if we're on a tagged commit
+VERSION=$(git describe --tags --exact-match 2>/dev/null || echo "")
+if [ -z "$VERSION" ]; then
+    echo "Error: Not on a tagged commit. Please create and push a tag first." >&2
+    exit 1
+fi
+
+echo "Releasing version $VERSION..."
+
+# Run goreleaser
+goreleaser release --clean
+
+# Index package with Go proxy
+echo ""
+echo "Indexing package with Go proxy..."
+echo "Indexing version: $VERSION"
+curl -f "https://proxy.golang.org/github.com/braintrustdata/braintrust-sdk-go/@v/$VERSION.info" || true
+echo ""
+echo "Package indexed successfully!"
+
+# Get repository URL
+REPO_URL=$(git config --get remote.origin.url | sed 's/git@github.com:/https:\/\/github.com\//' | sed 's/\.git$//')
+
+# Show completion information
+echo "RELEASE COMPLETE: $VERSION"
+echo ""
+echo "Note: Docs should be updated within the next hour. Request manually at the URL above"
+echo "if they don't show up"
+echo "- Release: $REPO_URL/releases/tag/$VERSION"
+echo "- Docs:    https://pkg.go.dev/github.com/braintrustdata/braintrust-sdk-go@$VERSION/braintrust"
+echo "- Index:   https://proxy.golang.org/github.com/braintrustdata/braintrust-sdk-go/@v/$VERSION.info"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -103,20 +103,21 @@ fi
 git tag -a "$VERSION" -m "Release $VERSION"
 git push origin "$VERSION"
 
-echo "Running goreleaser to update changelog..."
-goreleaser release --clean
-
-echo "Indexing package."
-curl "https://proxy.golang.org/github.com/braintrustdata/braintrust-sdk-go/@v/$VERSION.info"
-echo ""
-
 echo "================================================"
-echo " Release Complete $VERSION"
+echo " Tag Pushed: $VERSION"
 echo "================================================"
 echo
-echo "Note: Docs should be updated within the next hour. Request manually at the URL below"
-echo "if they don't show up"
+echo "The GitHub Actions workflow will now:"
+echo "  1. Run goreleaser to create the GitHub release"
+echo "  2. Index the package with the Go proxy"
 echo
-echo "- Index:   https://proxy.golang.org/github.com/braintrustdata/braintrust-sdk-go/@v/$VERSION.info"
-echo "- Docs:    https://pkg.go.dev/github.com/braintrustdata/braintrust-sdk-go@$VERSION/braintrust"
+echo "Monitor the release workflow at:"
+echo "  $REPO_URL/actions"
+echo
+echo "Once complete, check:"
 echo "- Release: $REPO_URL/releases/tag/$VERSION"
+echo "- Docs:    https://pkg.go.dev/github.com/braintrustdata/braintrust-sdk-go@$VERSION/braintrust"
+echo "- Index:   https://proxy.golang.org/github.com/braintrustdata/braintrust-sdk-go/@v/$VERSION.info"
+echo
+echo "Note: Docs should be updated within the next hour. Request manually at the URL above"
+echo "if they don't show up"


### PR DESCRIPTION
This breaks the go release process into two steps:

- release.sh: creates and pushes a git tag
- publish-release-from-tag.yml: runs go release for newly pushed tags

This allows contributes to release go sdk without needing a publish token.