### PR TITLE
Update docs link

### DIFF
--- a/trace/attachment/attachment.go
+++ b/trace/attachment/attachment.go
@@ -14,7 +14,7 @@
 //   - Custom scenarios not covered by auto-instrumentation
 //   - Writing instrumentation for new providers
 //
-// For more information, see: https://www.braintrust.dev/docs/guides/attachments
+// For more information, see: https://www.braintrust.dev/docs/instrument/attachments
 package attachment
 
 import (


### PR DESCRIPTION
URL changed with our new docs structure.

Addresses https://linear.app/braintrustdata/issue/DOC-5/update-docs-link-in-other-places