### PR TITLE
Pin orchestrion to 1.6.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           version: v2.1.6
       - name: Install orchestrion
-        run: go install github.com/DataDog/orchestrion@1.6.1
+        run: go install github.com/DataDog/orchestrion@v1.6.1
       - name: Lint, vet, tests, etc.
         run: make ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           version: v2.1.6
 
       - name: Install orchestrion
-        run: go install github.com/DataDog/orchestrion@1.6.1
+        run: go install github.com/DataDog/orchestrion@v1.6.1
 
       - name: Install goreleaser
         run: |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Use [Orchestrion](https://github.com/DataDog/orchestrion) to automatically injec
 
 **1. Install orchestrion:**
 ```bash
-go install github.com/DataDog/orchestrion@1.6.1
+go install github.com/DataDog/orchestrion@v1.6.1
 ```
 
 **2. Create `orchestrion.tool.go` in your project root:**

--- a/examples/internal/autoinstrumentation/Makefile
+++ b/examples/internal/autoinstrumentation/Makefile
@@ -4,7 +4,7 @@ help:
 	@echo "Auto-Instrumentation Example (using Orchestrion)"
 	@echo ""
 	@echo "Prerequisites:"
-	@echo "  go install github.com/DataDog/orchestrion@1.6.1"
+	@echo "  go install github.com/DataDog/orchestrion@v1.6.1"
 	@echo ""
 	@echo "Environment variables:"
 	@echo "  BRAINTRUST_API_KEY  - Braintrust API key"

--- a/trace/contrib/orchestrion_test.go
+++ b/trace/contrib/orchestrion_test.go
@@ -23,7 +23,7 @@ func TestOrchestrionInjection(t *testing.T) {
 
 	// Check orchestrion is available
 	if _, err := exec.LookPath("orchestrion"); err != nil {
-		t.Fatal("orchestrion not found in PATH (install: go install github.com/DataDog/orchestrion@1.6.1)")
+		t.Fatal("orchestrion not found in PATH (install: go install github.com/DataDog/orchestrion@v1.6.1)")
 	}
 
 	// Get the testdata directory


### PR DESCRIPTION
That's the version we currently use, since 1.7.0 came out two weeks ago, CI will break unless we either pin the version or upgrade.