### PR TITLE
Align trace structure for Evals with other SDKs

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -531,7 +531,7 @@ func (e *eval[I, R]) runScorers(ctx context.Context, taskResult TaskResult[I, R]
 
 // runScorer executes a single scorer in its own span named after the scorer.
 func (e *eval[I, R]) runScorer(ctx context.Context, scorer Scorer[I, R], taskResult TaskResult[I, R]) ([]Score, error) {
-	_, span := e.tracer.Start(ctx, scorer.Name(), e.startSpanOpt)
+	ctx, span := e.tracer.Start(ctx, scorer.Name(), e.startSpanOpt)
 	defer span.End()
 
 	spanAttrs := map[string]any{

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -179,6 +179,10 @@ func TestNewEval_Success(t *testing.T) {
 		},
 	})
 
+	// Task and scorer spans are children of the eval span.
+	spans[0].AssertChildOf(&spans[2])
+	spans[1].AssertChildOf(&spans[2])
+
 	spans[2].AssertEqual(oteltest.TestSpan{
 		Name: "eval",
 		Attrs: map[string]any{
@@ -229,6 +233,10 @@ func TestNewEval_Success(t *testing.T) {
 			"braintrust.output":   map[string]any{"score": 0.95},
 		},
 	})
+
+	// Task and scorer spans are children of the eval span.
+	spans[3].AssertChildOf(&spans[5])
+	spans[4].AssertChildOf(&spans[5])
 
 	spans[5].AssertEqual(oteltest.TestSpan{
 		Name: "eval",

--- a/internal/oteltest/oteltest.go
+++ b/internal/oteltest/oteltest.go
@@ -117,6 +117,15 @@ func (s *Span) AssertNameIs(expected string) {
 	assert.Equal(s.t, expected, s.Stub.Name)
 }
 
+// AssertChildOf asserts that this span is a child of the given parent span.
+func (s *Span) AssertChildOf(parent *Span) {
+	s.t.Helper()
+	assert.Equal(s.t, parent.Stub.SpanContext.SpanID(), s.Stub.Parent.SpanID(),
+		"expected span %q to be a child of span %q", s.Stub.Name, parent.Stub.Name)
+	assert.Equal(s.t, parent.Stub.SpanContext.TraceID(), s.Stub.SpanContext.TraceID(),
+		"expected span %q to share trace ID with parent span %q", s.Stub.Name, parent.Stub.Name)
+}
+
 // AssertInTimeRange asserts that the span's start and end times are within the given time range.
 func (s *Span) AssertInTimeRange(tr TimeRange) {
 	s.t.Helper()


### PR DESCRIPTION
This pull request aligns the Go SDK's eval span structure with the Java and Ruby SDKs (the other OTel-based SDKs). A previous Ruby fix (braintrustdata/braintrust-sdk-ruby#119) addressed the same class of problems there.

## Changes

| # | Issue | Before | After |
|---|-------|--------|-------|
| 1 | **One span for all scorers** | A single `"score"` span was created per eval case; all scorers ran inside it | Each scorer runs in its **own span**, named after the scorer |
| 2 | **Missing `purpose: "scorer"`** | `span_attributes` was `{"type": "score"}` | `span_attributes` is `{"type": "score", "name": "<scorer>", "purpose": "scorer"}` — the platform uses `purpose` to exclude scorer latency/cost from app metrics |
| 3 | **Scorer span name** | Span was always named `"score"` | Span is named after the scorer (e.g. `"accuracy"`) — consistent with Java, TypeScript, and Python |
| 4 | **Missing scorer `name` in span_attributes** | No `name` field in scorer `span_attributes` | `name` field set to the scorer's name, matching Java and Ruby |
| 5 | **No input on scorer spans** | Scorer span had no `braintrust.input_json` | Scorer span receives the full task result (`input`, `expected`, `output`) as `braintrust.input_json` |
| 6 | **Eval span empty on task failure** | If the task threw an error, `runCase` returned early and the eval span had no attributes at all | `input_json`, `expected`, `span_attributes`, `metadata`, `origin`, and `tags` are all set on the eval span **before** the task runs |
| 7 | **Eval span `output_json` missing on task failure** | `output_json` was never written when the task failed | `output_json` is explicitly set to `null` on task failure |
| 8 | **Task span `output_json` missing on failure** | Task span had no `output_json` when the task errored | `output_json` is explicitly set to `null` on the task span on failure |

## Span structure (per eval case)

**Before:**
```
Experiment
└── eval
    ├── task
    └── score          ← all scorers aggregated into one span
```

**After:**
```
Experiment
└── eval
    ├── task
    ├── accuracy       ← one span per scorer, named after it
    └── exact_match
```
