### PR TITLE
chore(go): update repo to test with go 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.23.x, 1.24.x, 1.25.x]
+        go-version: [1.24.x, 1.25.x, 1.26.x]
         # FIXME[matt] add windows testing, we need to fix some timing
         # tests.
         os: [ubuntu-latest, macos-latest]
@@ -29,7 +29,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.1.6
+          version: v2.11.4
       - name: Install orchestrion
         run: go install github.com/DataDog/orchestrion@v1.6.1
       - name: Lint, vet, tests, etc.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,9 @@ jobs:
         with:
           version: v2.11.4
       - name: Install orchestrion
-        run: go install github.com/DataDog/orchestrion@v1.6.1
+        run: |
+          GOTOOLCHAIN=$(awk '/^go /{print "go"$2; exit}' go.mod) \
+            go install github.com/DataDog/orchestrion@v1.6.1
       - name: Lint, vet, tests, etc.
         run: make ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.1.6
+          version: v2.11.4
 
       - name: Install orchestrion
         run: go install github.com/DataDog/orchestrion@v1.6.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,9 @@ jobs:
           version: v2.11.4
 
       - name: Install orchestrion
-        run: go install github.com/DataDog/orchestrion@v1.6.1
+        run: |
+          GOTOOLCHAIN=$(awk '/^go /{print "go"$2; exit}' go.mod) \
+            go install github.com/DataDog/orchestrion@v1.6.1
 
       - name: Install goreleaser
         run: |

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.1.6
+          version: v2.11.4
 
       - name: Install orchestrion
         run: go install github.com/DataDog/orchestrion@v1.6.1

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -39,7 +39,9 @@ jobs:
           version: v2.11.4
 
       - name: Install orchestrion
-        run: go install github.com/DataDog/orchestrion@v1.6.1
+        run: |
+          GOTOOLCHAIN=$(awk '/^go /{print "go"$2; exit}' go.mod) \
+            go install github.com/DataDog/orchestrion@v1.6.1
 
       - name: Run CI
         run: make ci

--- a/examples/adk/go.mod
+++ b/examples/adk/go.mod
@@ -1,6 +1,6 @@
 module main.go
 
-go 1.24.11
+go 1.26.1
 
 require (
 	github.com/braintrustdata/braintrust-sdk-go v0.2.0

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,8 +1,6 @@
 module github.com/braintrustdata/braintrust-sdk-go/examples
 
-go 1.24.4
-
-toolchain go1.24.11
+go 1.26.1
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.23.0

--- a/examples/internal/adk-parallel/go.mod
+++ b/examples/internal/adk-parallel/go.mod
@@ -1,6 +1,6 @@
 module parallel
 
-go 1.24.11
+go 1.26.1
 
 require (
 	github.com/braintrustdata/braintrust-sdk-go v0.2.0

--- a/examples/internal/autoinstrumentation/go.mod
+++ b/examples/internal/autoinstrumentation/go.mod
@@ -1,8 +1,6 @@
 module github.com/braintrustdata/braintrust-sdk-go/examples/internal/autoinstrumentation
 
-go 1.24.4
-
-toolchain go1.24.11
+go 1.26.1
 
 require (
 	github.com/DataDog/orchestrion v1.6.1

--- a/examples/internal/genai/go.mod
+++ b/examples/internal/genai/go.mod
@@ -1,6 +1,6 @@
 module example.com/genai
 
-go 1.24.8
+go 1.26.1
 
 replace github.com/braintrustdata/braintrust-sdk-go => ../../..
 

--- a/examples/internal/genkit/go.mod
+++ b/examples/internal/genkit/go.mod
@@ -1,6 +1,6 @@
 module genkit-example
 
-go 1.24.11
+go 1.26.1
 
 require (
 	github.com/braintrustdata/braintrust-sdk-go v0.2.0

--- a/examples/internal/langchaingo-anthropic/go.mod
+++ b/examples/internal/langchaingo-anthropic/go.mod
@@ -1,8 +1,6 @@
 module github.com/braintrustdata/braintrust-sdk-go/examples/internal/langchaingo-anthropic
 
-go 1.24.4
-
-toolchain go1.24.9
+go 1.26.1
 
 require (
 	github.com/braintrustdata/braintrust-sdk-go v0.0.0

--- a/examples/internal/langchaingo/go.mod
+++ b/examples/internal/langchaingo/go.mod
@@ -1,8 +1,6 @@
 module golden
 
-go 1.24.4
-
-toolchain go1.24.9
+go 1.26.1
 
 require (
 	github.com/braintrustdata/braintrust-sdk-go v0.0.0

--- a/examples/internal/openai-v1/go.mod
+++ b/examples/internal/openai-v1/go.mod
@@ -1,6 +1,6 @@
 module github.com/braintrustdata/braintrust-sdk-go/examples/internal/openai-v1
 
-go 1.23.12
+go 1.26.1
 
 replace github.com/braintrustdata/braintrust-sdk-go => ../../..
 

--- a/examples/internal/openai-v2/go.mod
+++ b/examples/internal/openai-v2/go.mod
@@ -1,6 +1,6 @@
 module examples
 
-go 1.23.12
+go 1.26.1
 
 require github.com/braintrustdata/braintrust-sdk-go v0.0.6
 

--- a/examples/internal/temporal/go.mod
+++ b/examples/internal/temporal/go.mod
@@ -1,6 +1,6 @@
 module github.com/braintrustdata/braintrust-sdk-go/examples/temporal
 
-go 1.23.0
+go 1.26.1
 
 replace github.com/braintrustdata/braintrust-sdk-go => ../..
 

--- a/examples/internal/temporal/mise.toml
+++ b/examples/internal/temporal/mise.toml
@@ -7,7 +7,7 @@ _.file = ".env"
 [tools]
 temporal = "latest"
 overmind = "latest"
-go = "1.23"
+go = "1.26"
 
 [tasks.server]
 description = "Run temporal server and worker"

--- a/examples/langchaingo/go.mod
+++ b/examples/langchaingo/go.mod
@@ -1,8 +1,6 @@
 module langchaingo
 
-go 1.24.4
-
-toolchain go1.24.9
+go 1.26.1
 
 require (
 	github.com/braintrustdata/braintrust-sdk-go v0.0.0

--- a/examples/openrouter/go.mod
+++ b/examples/openrouter/go.mod
@@ -1,6 +1,6 @@
 module openrouter-example
 
-go 1.23.12
+go 1.26.1
 
 require (
 	github.com/braintrustdata/braintrust-sdk-go v0.0.5

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/braintrustdata/braintrust-sdk-go
 
-go 1.24.4
-
-toolchain go1.24.11
+go 1.26.1
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/go.work
+++ b/go.work
@@ -1,6 +1,4 @@
-go 1.24.4
-
-toolchain go1.24.11
+go 1.26.1
 
 use (
 	.

--- a/internal/nestedmodules/testdata/repo/trace/contrib/all/go.mod
+++ b/internal/nestedmodules/testdata/repo/trace/contrib/all/go.mod
@@ -1,6 +1,6 @@
 module github.com/braintrustdata/braintrust-sdk-go/trace/contrib/all
 
-go 1.24.4
+go 1.26.1
 
 require (
 	github.com/braintrustdata/braintrust-sdk-go/trace/contrib/github.com/sashabaranov/go-openai v0.0.0

--- a/internal/nestedmodules/testdata/repo/trace/contrib/github.com/sashabaranov/go-openai/go.mod
+++ b/internal/nestedmodules/testdata/repo/trace/contrib/github.com/sashabaranov/go-openai/go.mod
@@ -1,6 +1,6 @@
 module github.com/braintrustdata/braintrust-sdk-go/trace/contrib/github.com/sashabaranov/go-openai
 
-go 1.24.4
+go 1.26.1
 
 require (
 	github.com/braintrustdata/braintrust-sdk-go v0.0.0

--- a/internal/nestedmodules/testdata/repo/trace/contrib/langchaingo/go.mod
+++ b/internal/nestedmodules/testdata/repo/trace/contrib/langchaingo/go.mod
@@ -1,5 +1,5 @@
 module github.com/braintrustdata/braintrust-sdk-go/trace/contrib/langchaingo
 
-go 1.24.4
+go 1.26.1
 
 require github.com/braintrustdata/braintrust-sdk-go v0.0.0

--- a/internal/nestedmodules/testdata/repo/trace/contrib/openai/go.mod
+++ b/internal/nestedmodules/testdata/repo/trace/contrib/openai/go.mod
@@ -1,5 +1,5 @@
 module github.com/braintrustdata/braintrust-sdk-go/trace/contrib/openai
 
-go 1.24.4
+go 1.26.1
 
 require github.com/braintrustdata/braintrust-sdk-go v0.0.0

--- a/mise.toml
+++ b/mise.toml
@@ -5,8 +5,8 @@ experimental=true
 _.file = ".env"
 
 [tools]
-go = ["1.23", "1.24", "1.25"]
-golangci-lint = "2.1.6"
+go = ["1.26"]
+golangci-lint = "2.11.4"
 goreleaser = "2.12.0"
 watchexec = "latest"
 

--- a/trace/attachment/attachment.go
+++ b/trace/attachment/attachment.go
@@ -110,7 +110,7 @@ func (a *Attachment) Base64URL() (string, error) {
 
 	// Stream encode the data
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("data:%s;base64,", a.contentType))
+	fmt.Fprintf(&buf, "data:%s;base64,", a.contentType)
 
 	encoder := base64.NewEncoder(base64.StdEncoding, &buf)
 	_, err := io.Copy(encoder, a.reader)

--- a/trace/contrib/adk/go.mod
+++ b/trace/contrib/adk/go.mod
@@ -1,8 +1,6 @@
 module github.com/braintrustdata/braintrust-sdk-go/trace/contrib/adk
 
-go 1.24.4
-
-toolchain go1.24.11
+go 1.26.1
 
 require (
 	github.com/braintrustdata/braintrust-sdk-go v0.4.0

--- a/trace/contrib/all/go.mod
+++ b/trace/contrib/all/go.mod
@@ -1,8 +1,6 @@
 module github.com/braintrustdata/braintrust-sdk-go/trace/contrib/all
 
-go 1.24.4
-
-toolchain go1.24.11
+go 1.26.1
 
 require (
 	github.com/braintrustdata/braintrust-sdk-go/trace/contrib/adk v0.4.0

--- a/trace/contrib/anthropic/go.mod
+++ b/trace/contrib/anthropic/go.mod
@@ -1,8 +1,6 @@
 module github.com/braintrustdata/braintrust-sdk-go/trace/contrib/anthropic
 
-go 1.24.4
-
-toolchain go1.24.11
+go 1.26.1
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.23.0

--- a/trace/contrib/cloudwego/eino/go.mod
+++ b/trace/contrib/cloudwego/eino/go.mod
@@ -1,8 +1,6 @@
 module github.com/braintrustdata/braintrust-sdk-go/trace/contrib/cloudwego/eino
 
-go 1.24.4
-
-toolchain go1.24.11
+go 1.26.1
 
 require (
 	github.com/braintrustdata/braintrust-sdk-go v0.4.0

--- a/trace/contrib/genai/go.mod
+++ b/trace/contrib/genai/go.mod
@@ -1,8 +1,6 @@
 module github.com/braintrustdata/braintrust-sdk-go/trace/contrib/genai
 
-go 1.24.4
-
-toolchain go1.24.11
+go 1.26.1
 
 require (
 	github.com/braintrustdata/braintrust-sdk-go v0.4.0

--- a/trace/contrib/genkit/go.mod
+++ b/trace/contrib/genkit/go.mod
@@ -1,8 +1,6 @@
 module github.com/braintrustdata/braintrust-sdk-go/trace/contrib/genkit
 
-go 1.24.4
-
-toolchain go1.24.11
+go 1.26.1
 
 require (
 	github.com/braintrustdata/braintrust-sdk-go v0.4.0

--- a/trace/contrib/github.com/sashabaranov/go-openai/go.mod
+++ b/trace/contrib/github.com/sashabaranov/go-openai/go.mod
@@ -1,8 +1,6 @@
 module github.com/braintrustdata/braintrust-sdk-go/trace/contrib/github.com/sashabaranov/go-openai
 
-go 1.24.4
-
-toolchain go1.24.11
+go 1.26.1
 
 require (
 	github.com/braintrustdata/braintrust-sdk-go v0.4.0

--- a/trace/contrib/langchaingo/go.mod
+++ b/trace/contrib/langchaingo/go.mod
@@ -1,8 +1,6 @@
 module github.com/braintrustdata/braintrust-sdk-go/trace/contrib/langchaingo
 
-go 1.24.4
-
-toolchain go1.24.11
+go 1.26.1
 
 require (
 	github.com/braintrustdata/braintrust-sdk-go v0.4.0

--- a/trace/contrib/openai/go.mod
+++ b/trace/contrib/openai/go.mod
@@ -1,8 +1,6 @@
 module github.com/braintrustdata/braintrust-sdk-go/trace/contrib/openai
 
-go 1.24.4
-
-toolchain go1.24.11
+go 1.26.1
 
 require (
 	github.com/braintrustdata/braintrust-sdk-go v0.4.0

--- a/trace/contrib/testdata/orchestrion/go.mod
+++ b/trace/contrib/testdata/orchestrion/go.mod
@@ -1,8 +1,6 @@
 module github.com/braintrustdata/braintrust-sdk-go/trace/contrib/testdata/orchestrion
 
-go 1.24.4
-
-toolchain go1.24.11
+go 1.26.1
 
 require (
 	github.com/DataDog/orchestrion v1.6.1


### PR DESCRIPTION
Bump the root module, workspace, examples, nested modules, and test fixtures to Go 1.26.1. Keep the CI matrix on the last three Go releases while pinning mise to 1.26 for local development.