### PR TITLE
feat: capture text parameter in Responses API tracer metadata

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "make fix"
+            "command": "make -C $(git rev-parse --show-toplevel) fix"
           }
         ]
       }

--- a/examples/internal/mise.toml
+++ b/examples/internal/mise.toml
@@ -1,0 +1,5 @@
+[env]
+# Internal examples are standalone modules with replace directives that conflict
+# with the repo root's go.work. Disable workspace mode so go commands resolve
+# dependencies from each example's own go.mod instead.
+GOWORK = "off"

--- a/examples/internal/openai-v2/main.go
+++ b/examples/internal/openai-v2/main.go
@@ -52,6 +52,7 @@ func main() {
 		{"chat-tools", chatTools},
 		{"chat-streaming-tools", chatStreamingTools},
 		{"responses", responsesAPI},
+		{"responses-structured-output", responsesStructuredOutput},
 		{"responses-streaming", responsesStreaming},
 		{"conversations", conversationsAPI},
 		{"models-list", modelsList},
@@ -250,6 +251,34 @@ func responsesAPI(ctx context.Context, client openai.Client) error {
 	output := resp.OutputText()
 	if len(output) > 50 {
 		output = output[:50] + "..."
+	}
+	fmt.Printf("  %s\n", output)
+	return nil
+}
+
+func responsesStructuredOutput(ctx context.Context, client openai.Client) error {
+	resp, err := client.Responses.New(ctx, responses.ResponseNewParams{
+		Input: responses.ResponseNewParamsInputUnion{OfString: openai.String("What is the capital of France? Return as JSON with fields: city, country, population.")},
+		Model: openai.ChatModelGPT4oMini,
+		Text: responses.ResponseTextConfigParam{
+			Format: responses.ResponseFormatTextConfigParamOfJSONSchema("capital_info", map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"city":       map[string]any{"type": "string"},
+					"country":    map[string]any{"type": "string"},
+					"population": map[string]any{"type": "number"},
+				},
+				"required":             []string{"city", "country", "population"},
+				"additionalProperties": false,
+			}),
+		},
+	})
+	if err != nil {
+		return err
+	}
+	output := resp.OutputText()
+	if len(output) > 80 {
+		output = output[:80] + "..."
 	}
 	fmt.Printf("  %s\n", output)
 	return nil

--- a/trace/contrib/openai/responses.go
+++ b/trace/contrib/openai/responses.go
@@ -1,6 +1,6 @@
 package openai
 
-//  this file parses the responses API.
+// this file parses the responses API.
 
 import (
 	"bufio"
@@ -66,6 +66,7 @@ func (rt *responsesTracer) StartSpan(ctx context.Context, t time.Time, request i
 		"tool_choice",
 		"seed",
 		"reasoning",
+		"text",
 	}
 
 	// handle simple fields here.
@@ -191,6 +192,7 @@ func (rt *responsesTracer) handleResponseCompletedMessage(span trace.Span, rawMs
 		"choices",
 		"content_filter_results",
 		"reasoning",
+		"text",
 	}
 
 	for _, field := range metadataFields {

--- a/trace/contrib/openai/traceopenai_test.go
+++ b/trace/contrib/openai/traceopenai_test.go
@@ -180,6 +180,16 @@ func TestOpenAIResponsesKitchenSink(t *testing.T) {
 	assert.Equal(false, metadata["store"])
 	assert.Equal("auto", metadata["truncation"])
 	assert.Equal(100.0, metadata["max_output_tokens"])
+
+	// text config should be captured in metadata (issue #70)
+	textConfig, ok := metadata["text"]
+	assert.True(ok, "text should be present in metadata")
+	assert.NotNil(textConfig, "text should not be nil")
+	textMap, ok := textConfig.(map[string]any)
+	require.True(ok, "text should be a map")
+	formatMap, ok := textMap["format"].(map[string]any)
+	require.True(ok, "text.format should be a map")
+	assert.Equal("text", formatMap["type"], "default text format type should be 'text'")
 }
 
 func TestOpenAIResponsesStreamingClose(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `text` to request and response metadata fields in the Responses API tracer, matching parity with `response_format` in Chat Completions
- Add test assertions verifying `text` config is captured in span metadata
- Add `responses-structured-output` internal example demonstrating JSON schema structured output via the Responses API
- Fix `make fix` hook to work from any subdirectory (worktree-safe)

Closes #70

## Test plan
- [x] `TestOpenAIResponsesKitchenSink` asserts `text` field is present in metadata with correct structure (`text.format.type == "text"`)
- [x] All existing openai tests pass (`go test ./trace/contrib/openai/`)
- [x] `make lint` passes with 0 issues
- [x] New example compiles (`GOWORK=off go build ./...` in `examples/internal/openai-v2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)