### PR TITLE
fix(openai): mark traced openai spans as llm

### DIFF
--- a/trace/contrib/openai/chatcompletions.go
+++ b/trace/contrib/openai/chatcompletions.go
@@ -94,6 +94,10 @@ func (ct *chatCompletionsTracer) StartSpan(ctx context.Context, t time.Time, req
 		}
 	}
 
+	if err := internal.SetJSONAttr(span, "braintrust.span_attributes", map[string]string{"type": "llm"}); err != nil {
+		return ctx, span, err
+	}
+
 	if err := internal.SetJSONAttr(span, "braintrust.metadata", ct.metadata); err != nil {
 		return ctx, span, err
 	}

--- a/trace/contrib/openai/chatcompletions.go
+++ b/trace/contrib/openai/chatcompletions.go
@@ -94,7 +94,8 @@ func (ct *chatCompletionsTracer) StartSpan(ctx context.Context, t time.Time, req
 		}
 	}
 
-	if err := internal.SetJSONAttr(span, "braintrust.span_attributes", map[string]string{"type": "llm"}); err != nil {
+	attrs := map[string]string{"type": "llm"}
+	if err := internal.SetJSONAttr(span, "braintrust.span_attributes", attrs); err != nil {
 		return ctx, span, err
 	}
 

--- a/trace/contrib/openai/chatcompletions_test.go
+++ b/trace/contrib/openai/chatcompletions_test.go
@@ -1074,6 +1074,7 @@ func assertChatSpanValid(t *testing.T, span oteltest.Span, timeRange oteltest.Ti
 
 	span.AssertInTimeRange(timeRange)
 	span.AssertNameIs("Chat Completion")
+	span.AssertJSONAttrEquals("braintrust.span_attributes", map[string]any{"type": "llm"})
 	assert.Equal(codes.Unset, span.Status().Code)
 
 	metadata := span.Metadata()

--- a/trace/contrib/openai/responses.go
+++ b/trace/contrib/openai/responses.go
@@ -90,6 +90,10 @@ func (rt *responsesTracer) StartSpan(ctx context.Context, t time.Time, request i
 		span.SetAttributes(attribute.String("braintrust.input_json", string(b)))
 	}
 
+	if err := internal.SetJSONAttr(span, "braintrust.span_attributes", map[string]string{"type": "llm"}); err != nil {
+		return ctx, span, err
+	}
+
 	b, err := json.Marshal(rt.metadata)
 	if err != nil {
 		return ctx, span, err

--- a/trace/contrib/openai/responses.go
+++ b/trace/contrib/openai/responses.go
@@ -90,7 +90,8 @@ func (rt *responsesTracer) StartSpan(ctx context.Context, t time.Time, request i
 		span.SetAttributes(attribute.String("braintrust.input_json", string(b)))
 	}
 
-	if err := internal.SetJSONAttr(span, "braintrust.span_attributes", map[string]string{"type": "llm"}); err != nil {
+	attrs := map[string]string{"type": "llm"}
+	if err := internal.SetJSONAttr(span, "braintrust.span_attributes", attrs); err != nil {
 		return ctx, span, err
 	}
 

--- a/trace/contrib/openai/traceopenai_test.go
+++ b/trace/contrib/openai/traceopenai_test.go
@@ -336,6 +336,7 @@ func assertSpanValid(t *testing.T, span oteltest.Span, timeRange oteltest.TimeRa
 
 	span.AssertInTimeRange(timeRange)
 	span.AssertNameIs("openai.responses.create")
+	span.AssertJSONAttrEquals("braintrust.span_attributes", map[string]any{"type": "llm"})
 	assert.Equal(codes.Unset, span.Stub.Status.Code)
 
 	metadata := span.Metadata()


### PR DESCRIPTION
Set braintrust.span_attributes.type to "llm" for the chat completions and responses tracers so Braintrust classifies emitted spans correctly in the UI.

Extend the VCR-backed OpenAI assertions to verify the attribute is present on exported spans.

Fixes #81