### PR TITLE
test(contrib): parallelize orchestrion injection subtests

### DIFF
--- a/trace/contrib/orchestrion_test.go
+++ b/trace/contrib/orchestrion_test.go
@@ -57,6 +57,7 @@ func TestOrchestrionInjection(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			fixtureDir := prepareOrchestrionFixture(t, repoRoot, tc.imports)
 
 			// Run the inner tests with orchestrion - this compiles with middleware injection.


### PR DESCRIPTION
## Summary

The two `TestOrchestrionInjection` subtests ("all" and "individual") each prepare an independent fixture in `t.TempDir()` and run a full `orchestrion go test` compile+run cycle. They're compile-heavy and independent, so `t.Parallel()` cuts wall time roughly in half on a multi-core host.

## Measurement

Warm-cache local (`go clean -testcache` between runs):

| mode | run 1 | run 2 |
|---|---|---|
| serial | 8.08s | 7.24s |
| parallel | 4.98s | 4.32s |

On CI the gain depends on runner cores; on a 2-core ubuntu runner expect a smaller but still meaningful reduction in the dominant step of `make test`.

## Test plan

- [x] `make lint`
- [x] `go test -run=TestOrchestrionInjection ./trace/contrib/` passes
- [ ] CI green across the matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)