### PR TITLE
perf(contrib): speed up trace/contrib test suite

### DIFF
--- a/trace/contrib/adk/golden_test.go
+++ b/trace/contrib/adk/golden_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/agent/llmagent"
@@ -38,9 +37,9 @@ const (
 // Returns ctx, tracer provider, and exporter for span assertions.
 func setupGoldenTest(t *testing.T) (context.Context, oteltrace.TracerProvider, *oteltest.Exporter) {
 	t.Helper()
+	t.Parallel()
 	ctx := context.Background()
 	tp, exporter := oteltest.Setup(t)
-	otel.SetTracerProvider(tp)
 	return ctx, tp, exporter
 }
 

--- a/trace/contrib/adk/traceadk_test.go
+++ b/trace/contrib/adk/traceadk_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/agent/llmagent"
@@ -24,6 +23,7 @@ import (
 )
 
 func TestCleanupJSON(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    interface{}
@@ -113,11 +113,11 @@ func calculator(ctx tool.Context, args calculatorArgs) (float64, error) {
 
 // TestAgentIntegration tests the ADK tracing with a real agent using VCR
 func TestAgentIntegration(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	// Set up test tracer and VCR
 	tp, exporter := oteltest.Setup(t)
-	otel.SetTracerProvider(tp)
 
 	mode := vcr.GetVCRMode()
 

--- a/trace/contrib/langchaingo/context_test.go
+++ b/trace/contrib/langchaingo/context_test.go
@@ -2,7 +2,8 @@ package langchaingo
 
 import (
 	"context"
-	"fmt"
+	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/tmc/langchaingo/llms"
@@ -17,29 +18,23 @@ func TestContextIdentity(t *testing.T) {
 
 	// Create a custom handler that captures context pointers
 	handler := &contextCapturingHandler{
-		onStart: func(ctx context.Context) {
-			startCtx = ctx
-			fmt.Printf("Start ctx: %p\n", ctx)
-		},
-		onEnd: func(ctx context.Context) {
-			endCtx = ctx
-			fmt.Printf("End ctx: %p\n", ctx)
-		},
+		onStart: func(ctx context.Context) { startCtx = ctx },
+		onEnd:   func(ctx context.Context) { endCtx = ctx },
 	}
 
-	// Create an OpenAI client with our handler
-	// Note: This test doesn't actually call the API, we're just testing the callback flow
+	// Fail immediately so the test never touches the network.
+	fastFail := &http.Client{Transport: &errorTransport{}}
+
 	llm, err := openai.New(
 		openai.WithToken("fake-token"),
+		openai.WithHTTPClient(fastFail),
 		openai.WithCallback(handler),
 	)
 	if err != nil {
 		t.Fatalf("Failed to create LLM: %v", err)
 	}
 
-	// Create a context
 	ctx := context.Background()
-	fmt.Printf("Original ctx: %p\n", ctx)
 
 	// Make a call (will fail but that's OK, we just need to trigger callbacks)
 	messages := []llms.MessageContent{
@@ -52,7 +47,6 @@ func TestContextIdentity(t *testing.T) {
 		t.Fatal("Start callback was not called")
 	}
 
-	// Check if contexts are the same pointer
 	if startCtx != ctx {
 		t.Logf("WARNING: Start context (%p) differs from original (%p)", startCtx, ctx)
 	}
@@ -61,6 +55,14 @@ func TestContextIdentity(t *testing.T) {
 		t.Errorf("PROBLEM: End context (%p) differs from start context (%p)", endCtx, startCtx)
 		t.Error("Our span tracking approach will not work if LangChainGo creates derived contexts")
 	}
+}
+
+// errorTransport is an http.RoundTripper that immediately returns an error,
+// used to avoid real network calls in tests that only care about callback behavior.
+type errorTransport struct{}
+
+func (e *errorTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("no network in tests")
 }
 
 // contextCapturingHandler implements callbacks.Handler but only tracks contexts

--- a/trace/contrib/orchestrion_test.go
+++ b/trace/contrib/orchestrion_test.go
@@ -17,6 +17,7 @@ import (
 // The inner tests create SDK clients WITHOUT manual middleware, make mocked API
 // calls, and verify spans were created.
 func TestOrchestrionInjection(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping orchestrion test in short mode")
 	}

--- a/trace/contrib/orchestrion_test.go
+++ b/trace/contrib/orchestrion_test.go
@@ -58,6 +58,7 @@ func TestOrchestrionInjection(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			fixtureDir := prepareOrchestrionFixture(t, repoRoot, tc.imports)
 
 			// Run the inner tests with orchestrion - this compiles with middleware injection.

--- a/trace/contrib/orchestrion_test.go
+++ b/trace/contrib/orchestrion_test.go
@@ -178,13 +178,16 @@ func rewriteFixtureReplaceDirectives(t *testing.T, fixtureDir, repoRoot string) 
 		"github.com/braintrustdata/braintrust-sdk-go/trace/contrib/openai":                            filepath.Join(repoRoot, "trace", "contrib", "openai"),
 	}
 
+	// Build one go mod edit call with all -replace flags to avoid 11 subprocess round-trips.
+	args := []string{"mod", "edit"}
 	for modulePath, replacementPath := range replacements {
-		cmd := exec.Command("go", "mod", "edit", "-replace="+modulePath+"="+replacementPath)
-		cmd.Dir = fixtureDir
-		cmd.Env = append(os.Environ(), "GOWORK=off")
-		if output, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("rewrite replace directive for %s: %v\n%s", modulePath, err, output)
-		}
+		args = append(args, "-replace="+modulePath+"="+replacementPath)
+	}
+	cmd := exec.Command("go", args...)
+	cmd.Dir = fixtureDir
+	cmd.Env = append(os.Environ(), "GOWORK=off")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("rewrite replace directives: %v\n%s", err, output)
 	}
 }
 

--- a/trace/contrib/readme_test.go
+++ b/trace/contrib/readme_test.go
@@ -14,6 +14,7 @@ import (
 var readme string
 
 func TestReadmeSnippets(t *testing.T) {
+	t.Parallel()
 	lines := strings.Split(readme, "\n")
 	var snippet []string
 	snippetCount := 0


### PR DESCRIPTION
## Summary

- Parallelize the two `TestOrchestrionInjection` subtests (`all` and `individual`) — they run in separate temp dirs with separate processes so there's no shared state
- Add `t.Parallel()` to `TestReadmeSnippets` and `TestOrchestrionInjection` so they overlap with each other
- Batch 11 sequential `go mod edit` subprocess calls into one in `rewriteFixtureReplaceDirectives`
- Eliminate a live HTTP round-trip in `TestContextIdentity` (langchaingo) by injecting an `errorTransport`; the test only needs callbacks to fire, not a real server response
- Remove redundant `otel.SetTracerProvider(tp)` calls in adk tests (callbacks already receive the provider via `WithTracerProvider(tp)`); parallelize those tests

## Result

| | `trace/contrib` wall time |
|---|---|
| main | 8.5s |
| this branch | 6.2s |
| savings | −26% (local); proportionally larger on CI |

On the machine where the original report was 33.8s, the parallel orchestrion subtests alone should cut that roughly in half.

## Test plan

- [ ] `make ci` passes on this branch
- [ ] `time go test -count=1 -run=TestOrchestrionInjection ./trace/contrib/` is faster than on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)