### PR TITLE
perf(ci): run orchestrion tests in a dedicated job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,6 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Install orchestrion
-        env:
-          GOTOOLCHAIN: local
-        run: go install github.com/DataDog/orchestrion@v1.6.1
       - name: Verify modules
         run: make mod-verify
         env:
@@ -56,9 +52,32 @@ jobs:
         env:
           GOTOOLCHAIN: local
 
+  orchestrion:
+    runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: 0
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY}}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY}}
+      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY}}
+      RUN_ORCHESTRION_TESTS: "1"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: 1.26.x
+      - name: Install orchestrion
+        env:
+          GOTOOLCHAIN: local
+        run: go install github.com/DataDog/orchestrion@v1.6.1
+      - name: Test orchestrion injection
+        run: VCR_MODE=replay go test -run=TestOrchestrionInjection -count=1 ./trace/contrib/
+        env:
+          GOTOOLCHAIN: local
+
   ci-passed:
     name: ci-passed
-    needs: [lint, test]
+    needs: [lint, test, orchestrion]
     runs-on: ubuntu-latest
     steps:
       - name: Mark CI as passed

--- a/trace/contrib/orchestrion_test.go
+++ b/trace/contrib/orchestrion_test.go
@@ -22,6 +22,12 @@ func TestOrchestrionInjection(t *testing.T) {
 		t.Skip("skipping orchestrion test in short mode")
 	}
 
+	// In CI this test runs in a dedicated job (RUN_ORCHESTRION_TESTS=1).
+	// Skip it in the main matrix so the 6 platform jobs stay fast (~30s each).
+	if os.Getenv("GITHUB_ACTIONS") == "true" && os.Getenv("RUN_ORCHESTRION_TESTS") != "1" {
+		t.Skip("orchestrion tests run in a dedicated CI job; set RUN_ORCHESTRION_TESTS=1 to run locally in CI")
+	}
+
 	// Check orchestrion is available.
 	if _, err := exec.LookPath("orchestrion"); err != nil {
 		t.Fatal("orchestrion not found in PATH (install: go install github.com/DataDog/orchestrion@v1.6.1)")


### PR DESCRIPTION
## Summary

- `TestOrchestrionInjection` took ~86s and ran in all 6 matrix jobs, making each job ~3min
- Now skips in the main matrix when `GITHUB_ACTIONS=true` and `RUN_ORCHESTRION_TESTS` is unset
- New dedicated `orchestrion` job (ubuntu, Go 1.26) runs it with `RUN_ORCHESTRION_TESTS=1`
- `ci-passed` requires all three: `lint`, `test`, `orchestrion`

## Expected result

| Job | Before | After |
|-----|--------|-------|
| test matrix (×6) | ~3min | ~30s |
| orchestrion (×1) | — | ~90s |
| Overall CI wait | ~3–5min | ~90s |

`make test` locally is unchanged — `GITHUB_ACTIONS` is not set so orchestrion runs normally.

## Test plan

- [ ] Main matrix jobs finish in ~30s
- [ ] Orchestrion job finishes in ~90s and passes
- [ ] `ci-passed` requires all jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)