### PR TITLE
fix(eval): escape org name in permalink URL

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -31,6 +31,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"sync"
 	"time"
 
@@ -620,7 +621,7 @@ func (e *eval[I, R]) permalink() string {
 	}
 
 	if orgName != "" && e.experimentID != "" {
-		return fmt.Sprintf("%s/app/%s/object?object_type=experiment&object_id=%s", appURL, orgName, e.experimentID)
+		return fmt.Sprintf("%s/app/%s/object?object_type=experiment&object_id=%s", appURL, url.PathEscape(orgName), e.experimentID)
 	}
 
 	return ""

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -11,6 +11,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 
+	"github.com/braintrustdata/braintrust-sdk-go/internal/auth"
+	"github.com/braintrustdata/braintrust-sdk-go/internal/logger"
 	"github.com/braintrustdata/braintrust-sdk-go/internal/oteltest"
 	"github.com/braintrustdata/braintrust-sdk-go/internal/tests"
 	"github.com/braintrustdata/braintrust-sdk-go/trace"
@@ -250,6 +252,40 @@ func TestNewEval_Success(t *testing.T) {
 			"braintrust.span_attributes": map[string]any{"type": "eval"},
 		},
 	})
+}
+
+func TestPermalink_EscapesOrgName(t *testing.T) {
+	t.Parallel()
+
+	session := auth.NewTestSession(
+		auth.TestAPIKey,
+		"org-test-12345",
+		"Test Org With Space",
+		"https://api-test.braintrust.dev",
+		"https://test.braintrust.dev",
+		"https://test.braintrust.dev",
+		logger.NewFailTestLogger(t),
+	)
+
+	tp, _ := oteltest.Setup(t)
+	task := T(func(ctx context.Context, input testInput) (testOutput, error) {
+		return testOutput{}, nil
+	})
+	e := testNewEval[testInput, testOutput](
+		session,
+		tp.Tracer(t.Name()),
+		"exp-12345678",
+		"test-experiment",
+		"proj-87654321",
+		"test-project",
+		NewDataset([]Case[testInput, testOutput]{}),
+		task,
+		nil,
+		1,
+	)
+
+	const want = "https://test.braintrust.dev/app/Test%20Org%20With%20Space/object?object_type=experiment&object_id=exp-12345678"
+	assert.Equal(t, want, e.permalink())
 }
 
 func TestNewEval_Parallelism(t *testing.T) {


### PR DESCRIPTION
## Summary
- Wrap `orgName` with `url.PathEscape` in `eval.permalink()` so org names with spaces produce clickable URLs in terminals (previously emitted literal spaces).
- Add `TestPermalink_EscapesOrgName` covering an org name with spaces; the existing fixture used `test-org` and didn't catch this.

## Test plan
- [x] `go test -v -run=TestPermalink_EscapesOrgName ./eval`
- [x] `go test ./eval`
- [x] `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)