### PR TITLE
ci(release): add changeset link to release PR body

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -57,6 +59,21 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
+      - name: Compute changeset link
+        id: changeset
+        env:
+          VERSION: ${{ inputs.version }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+        run: |
+          LAST_TAG=$(git tag --sort=-version:refname | grep -v -- '-rc' | head -n 1 || true)
+          if [[ -n "$LAST_TAG" ]]; then
+            URL="${REPO_URL}/compare/${LAST_TAG}...release/${VERSION}"
+            echo "body=Changeset since [\`${LAST_TAG}\`](${REPO_URL}/releases/tag/${LAST_TAG}): ${URL}" >> "$GITHUB_OUTPUT"
+          else
+            URL="${REPO_URL}/commits/release/${VERSION}"
+            echo "body=Changeset: ${URL}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
@@ -65,4 +82,7 @@ jobs:
           branch: release/${{ inputs.version }}
           commit-message: "chore: release ${{ inputs.version }}"
           title: "chore: release ${{ inputs.version }}"
-          body: "Automated release PR for `${{ inputs.version }}`. Merging will trigger CI, tag creation, and publishing."
+          body: |
+            Automated release PR for `${{ inputs.version }}`. Merging will trigger CI, tag creation, and publishing.
+
+            ${{ steps.changeset.outputs.body }}


### PR DESCRIPTION
## Summary
- Restore the changeset (compare-URL) link in the automated release PR body, bringing back functionality from the previous `scripts/release.sh`-based flow.
- `prepare-release.yml` now fetches full history, computes the latest non-RC tag, and renders `compare/<last_tag>...release/<version>` into the PR description.

## Test plan
- [ ] Trigger the `Prepare Release` workflow for a test version and confirm the opened PR body contains the changeset link pointing at the correct compare URL.
- [ ] Verify the fallback branch (no prior tags) still produces a valid `commits/release/<version>` link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)