### PR TITLE
feat(openai): record streaming errors on responses API span

### DIFF
--- a/examples/internal/openai-v2/main.go
+++ b/examples/internal/openai-v2/main.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/openai/openai-go/v2"
 	"github.com/openai/openai-go/v2/conversations"
@@ -54,6 +55,7 @@ func main() {
 		{"responses", responsesAPI},
 		{"responses-structured-output", responsesStructuredOutput},
 		{"responses-streaming", responsesStreaming},
+		{"responses-streaming-error", responsesStreamingError},
 		{"conversations", conversationsAPI},
 		{"models-list", modelsList},
 		{"chat-vision", chatVision},
@@ -305,6 +307,26 @@ func responsesStreaming(ctx context.Context, client openai.Client) error {
 		final = final[:30] + "..."
 	}
 	fmt.Printf("  %s\n", final)
+	return nil
+}
+
+// responsesStreamingError exercises the streaming error path: it sends an
+// input well over the model's context window so OpenAI returns a mid-stream
+// `type: error` event. The middleware marks the span with an OTel error
+// status + exception event so the failure is visible in the trace.
+func responsesStreamingError(ctx context.Context, client openai.Client) error {
+	huge := strings.Repeat("context overflow ", 20000)
+	stream := client.Responses.NewStreaming(ctx, responses.ResponseNewParams{
+		Model: openai.ChatModelGPT4,
+		Input: responses.ResponseNewParamsInputUnion{OfString: openai.String(huge)},
+	})
+	for stream.Next() {
+	}
+	if err := stream.Err(); err != nil {
+		fmt.Printf("  stream errored as expected: %v\n", err)
+		return nil
+	}
+	fmt.Println("  stream completed without an error (model may have accepted the input)")
 	return nil
 }
 

--- a/trace/contrib/openai/responses.go
+++ b/trace/contrib/openai/responses.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"strings"
 	"time"
@@ -110,6 +111,7 @@ func (rt *responsesTracer) parseStreamingResponse(span trace.Span, body io.Reade
 	scanner := bufio.NewScanner(body)
 	var timeToFirstToken time.Duration
 	var completedMsg map[string]any
+	var streamError string
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -130,9 +132,9 @@ func (rt *responsesTracer) parseStreamingResponse(span trace.Span, body io.Reade
 		}
 
 		if msgType, ok := envelope["type"].(string); ok {
-			// the response.completed message has everything, so just parse that. Should we
-			// parse the other messages too?
-			if msgType == "response.completed" {
+			switch msgType {
+			case "response.completed":
+				// the response.completed message has everything, so just parse that.
 				if msg, ok := envelope["response"].(map[string]any); ok {
 					// For streaming responses, copy extra fields from the envelope
 					// that might be present in the outer wrapper
@@ -142,6 +144,15 @@ func (rt *responsesTracer) parseStreamingResponse(span trace.Span, body io.Reade
 						}
 					}
 					completedMsg = msg
+				}
+			case "error":
+				// OpenAI Responses API delivers stream errors (e.g. context_length_exceeded)
+				// as HTTP 200 responses with a `type: error` data event. Capture the envelope
+				// verbatim so downstream consumers can see the code/message/param.
+				if b, err := json.Marshal(envelope); err == nil {
+					streamError = string(b)
+				} else {
+					streamError = line
 				}
 			}
 		}
@@ -156,8 +167,20 @@ func (rt *responsesTracer) parseStreamingResponse(span trace.Span, body io.Reade
 		if err := rt.handleResponseCompletedMessage(span, completedMsg, timeToFirstToken); err != nil {
 			return err
 		}
+		return nil
 	}
 
+	// If the stream carried an explicit error event (OpenAI delivers errors like
+	// context_length_exceeded as HTTP 200 with a `type: error` data event),
+	// surface it so the middleware can mark the span as errored via
+	// span.RecordError / span.SetStatus (issue #113).
+	if streamError != "" {
+		return errors.New(streamError)
+	}
+
+	// Stream ended without response.completed and no error event — likely a
+	// client-side close. Don't flag it as an error because we can't distinguish
+	// truncation from a clean abort.
 	return nil
 }
 

--- a/trace/contrib/openai/testdata/cassettes/TestResponsesStreamingErrorEventEndToEnd.yaml
+++ b/trace/contrib/openai/testdata/cassettes/TestResponsesStreamingErrorEventEndToEnd.yaml
@@ -1,0 +1,3 @@
+---
+version: 2
+interactions: []

--- a/trace/contrib/openai/traceopenai_test.go
+++ b/trace/contrib/openai/traceopenai_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
@@ -570,4 +573,122 @@ func TestResponsesAPIWithReasoning(t *testing.T) {
 	require.True(ok, "reasoning should be a map")
 	assert.Equal("low", reasonMap["effort"], "effort should be 'low'")
 	assert.Contains([]string{"auto", "detailed", "concise"}, reasonMap["summary"], "summary should be a valid value")
+}
+
+// TestResponsesStreamingErrorEvent verifies that when the stream carries a
+// `type: error` event (e.g. context_length_exceeded), TagSpan returns an
+// error so the middleware can mark the span with the standard OTel error
+// signals (issue #113).
+func TestResponsesStreamingErrorEvent(t *testing.T) {
+	tp, _ := oteltest.Setup(t)
+	assert := assert.New(t)
+	require := require.New(t)
+
+	rt := newResponsesTracer(&middlewareConfig{tracerProvider: tp})
+	rt.streaming = true
+
+	reqBody := strings.NewReader(`{"model":"gpt-4","input":"hi","stream":true}`)
+	_, span, err := rt.StartSpan(context.Background(), time.Now(), reqBody)
+	require.NoError(err)
+
+	stream := strings.Join([]string{
+		`event: error`,
+		`data: {"type":"error","code":"context_length_exceeded","message":"This model's maximum context length is 8192 tokens.","param":null,"sequence_number":1}`,
+		``,
+		``,
+	}, "\n")
+
+	tagErr := rt.TagSpan(span, strings.NewReader(stream))
+	span.End()
+
+	require.Error(tagErr, "TagSpan should return an error when the stream carries an error event")
+	assert.Contains(tagErr.Error(), "context_length_exceeded")
+}
+
+// TestResponsesStreamingEndsWithoutCompleted verifies that when the stream
+// ends without a response.completed event and no error event, TagSpan does
+// not surface an error — the truncation could be a legitimate client-side
+// close, so we don't want to mark the span as failed.
+func TestResponsesStreamingEndsWithoutCompleted(t *testing.T) {
+	tp, _ := oteltest.Setup(t)
+	require := require.New(t)
+
+	rt := newResponsesTracer(&middlewareConfig{tracerProvider: tp})
+	rt.streaming = true
+
+	reqBody := strings.NewReader(`{"model":"gpt-4","input":"hi","stream":true}`)
+	_, span, err := rt.StartSpan(context.Background(), time.Now(), reqBody)
+	require.NoError(err)
+
+	stream := strings.Join([]string{
+		`event: response.created`,
+		`data: {"type":"response.created","sequence_number":0}`,
+		``,
+		``,
+	}, "\n")
+
+	tagErr := rt.TagSpan(span, strings.NewReader(stream))
+	span.End()
+
+	require.NoError(tagErr, "an incomplete stream without a type:error event should not be surfaced as an OTel error")
+}
+
+// TestResponsesStreamingErrorEventEndToEnd runs the full middleware +
+// openai client path for a streaming response whose body carries a
+// `type: error` event. The span should end with OTel error status and a
+// recorded exception event (issue #113).
+func TestResponsesStreamingErrorEventEndToEnd(t *testing.T) {
+	_, tp, exporter := setUpTest(t)
+	assert := assert.New(t)
+	require := require.New(t)
+
+	errorBody := strings.Join([]string{
+		`event: response.created`,
+		`data: {"type":"response.created","sequence_number":0}`,
+		``,
+		`event: error`,
+		`data: {"type":"error","code":"context_length_exceeded","message":"This model's maximum context length is 8192 tokens.","sequence_number":1}`,
+		``,
+		``,
+	}, "\n")
+
+	streamware := func(_ *http.Request, _ NextMiddleware) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       io.NopCloser(strings.NewReader(errorBody)),
+		}, nil
+	}
+
+	client := openai.NewClient(
+		option.WithMaxRetries(0),
+		option.WithMiddleware(NewMiddleware(WithTracerProvider(tp))), //nolint:bodyclose // false positive - NewMiddleware returns middleware func
+		option.WithMiddleware(streamware),
+	)
+
+	stream := client.Responses.NewStreaming(context.Background(), responses.ResponseNewParams{
+		Input: responses.ResponseNewParamsInputUnion{OfString: openai.String("hai")},
+		Model: testModel,
+	})
+	// Drain so the middleware gets the whole body.
+	for stream.Next() {
+	}
+	require.NoError(stream.Close())
+
+	ts := exporter.FlushOne()
+	assert.Equal(codes.Error, ts.Stub.Status.Code)
+	assert.Contains(ts.Stub.Status.Description, "context_length_exceeded")
+
+	// Verify an exception event was recorded with the error message.
+	var found bool
+	for _, ev := range ts.Stub.Events {
+		if ev.Name == "exception" {
+			for _, a := range ev.Attributes {
+				if string(a.Key) == "exception.message" && strings.Contains(a.Value.AsString(), "context_length_exceeded") {
+					found = true
+				}
+			}
+		}
+	}
+	assert.True(found, "expected an exception event with the stream error message")
 }

--- a/trace/internal/middleware.go
+++ b/trace/internal/middleware.go
@@ -90,6 +90,8 @@ func Middleware(getMiddlewareTracer TracerRouter, log logger.Logger) func(*http.
 			now := time.Now()
 			if err := mt.TagSpan(span, r); err != nil {
 				log.Warn("Error tagging span", "error", err)
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
 			}
 			span.End(trace.WithTimestamp(now))
 		}

--- a/trace/internal/utils_test.go
+++ b/trace/internal/utils_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/braintrustdata/braintrust-sdk-go/internal/oteltest"
@@ -261,4 +263,75 @@ func TestToInt64(t *testing.T) {
 			}
 		})
 	}
+}
+
+// errorTagSpanTracer is a MiddlewareTracer whose TagSpan always returns an error.
+type errorTagSpanTracer struct {
+	tp       trace.TracerProvider
+	tagErr   error
+	startErr error
+}
+
+func (e *errorTagSpanTracer) StartSpan(ctx context.Context, start time.Time, _ io.Reader) (context.Context, trace.Span, error) {
+	tracer := e.tp.Tracer("braintrust")
+	newCtx, span := tracer.Start(ctx, "error-tagspan-span", trace.WithTimestamp(start))
+	return newCtx, span, e.startErr
+}
+
+func (e *errorTagSpanTracer) TagSpan(_ trace.Span, _ io.Reader) error {
+	return e.tagErr
+}
+
+// TestMiddlewarePropagatesTagSpanError verifies the middleware calls
+// span.RecordError and span.SetStatus(codes.Error, ...) when TagSpan returns
+// a non-nil error, matching the transport-level error path (issue #113).
+func TestMiddlewarePropagatesTagSpanError(t *testing.T) {
+	tp, exporter := oteltest.Setup(t)
+
+	tagErr := errors.New("stream ended with error: context_length_exceeded")
+	mt := &errorTagSpanTracer{tp: tp, tagErr: tagErr}
+
+	router := func(path string) MiddlewareTracer {
+		return mt
+	}
+
+	middleware := Middleware(router, nil) //nolint:bodyclose // false positive - responses closed by the test
+
+	req := httptest.NewRequest("POST", "/v1/responses", strings.NewReader(`{"stream":true}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	next := func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       io.NopCloser(strings.NewReader(`event: error` + "\n" + `data: {"type":"error"}` + "\n\n")),
+		}, nil
+	}
+
+	resp, err := middleware(req, next)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	_, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	ts := exporter.FlushOne()
+	assert.Equal(t, codes.Error, ts.Stub.Status.Code, "span status should be Error when TagSpan returns an error")
+	assert.Contains(t, ts.Stub.Status.Description, "context_length_exceeded")
+
+	// Verify the error was recorded as an exception event on the span.
+	events := ts.Stub.Events
+	require.NotEmpty(t, events, "expected at least one event recording the error")
+	var found bool
+	for _, ev := range events {
+		if ev.Name == "exception" {
+			for _, attr := range ev.Attributes {
+				if string(attr.Key) == "exception.message" && strings.Contains(attr.Value.AsString(), "context_length_exceeded") {
+					found = true
+				}
+			}
+		}
+	}
+	assert.True(t, found, "expected an exception event with the TagSpan error message")
 }


### PR DESCRIPTION
## Summary
- Capture mid-stream `type: error` events (e.g. `context_length_exceeded`) in the Responses API tracer and surface them from `TagSpan`
- Middleware now marks the span with OTel error status + exception event when `TagSpan` returns an error, matching the existing transport-error path
- Adds a `responses-streaming-error` example that intentionally overflows the context window

Fixes #113

## Test plan
- [x] Unit test: `parseStreamingResponse` returns an error and captures the envelope when a `type: error` event is delivered (`TestResponsesStreamingErrorEvent`)
- [x] Unit test: stream that ends without `response.completed` but no error event is NOT surfaced as an OTel error (`TestResponsesStreamingEndsWithoutCompleted`) — avoids false positives on client-side close
- [x] End-to-end test: full middleware + openai client streaming path produces a span with `codes.Error` status and an `exception` event (`TestResponsesStreamingErrorEventEndToEnd`)
- [x] Middleware test: `span.RecordError` + `span.SetStatus` are called when `TagSpan` returns an error (`TestMiddlewarePropagatesTagSpanError`)
- [x] `make lint` clean, all `./trace/...` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)