### PR TITLE
feat(attachments): add json attachment uploads

### DIFF
--- a/api/attachment/attachment.go
+++ b/api/attachment/attachment.go
@@ -1,0 +1,75 @@
+// Package attachment provides operations for managing Braintrust attachments.
+package attachment
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/braintrustdata/braintrust-sdk-go/internal/https"
+)
+
+// API provides attachment API operations.
+type API struct {
+	client *https.Client
+}
+
+// New creates a new attachment API client.
+func New(client *https.Client) *API {
+	return &API{client: client}
+}
+
+// RequestUploadURL requests a signed object-store URL for an attachment upload.
+func (a *API) RequestUploadURL(ctx context.Context, params UploadURLParams) (*UploadURLResponse, error) {
+	if params.Key == "" {
+		return nil, fmt.Errorf("attachment key is required")
+	}
+	if params.Filename == "" {
+		return nil, fmt.Errorf("attachment filename is required")
+	}
+	if params.ContentType == "" {
+		return nil, fmt.Errorf("attachment content type is required")
+	}
+	if params.OrgID == "" {
+		return nil, fmt.Errorf("org ID is required")
+	}
+
+	resp, err := a.client.POST(ctx, "/attachment", params)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result UploadURLResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("error decoding response: %w", err)
+	}
+	if result.SignedURL == "" {
+		return nil, fmt.Errorf("signed URL response missing signedUrl")
+	}
+	if result.Headers == nil {
+		result.Headers = map[string]string{}
+	}
+
+	return &result, nil
+}
+
+// UpdateStatus updates attachment upload status.
+func (a *API) UpdateStatus(ctx context.Context, params StatusParams) error {
+	if params.Key == "" {
+		return fmt.Errorf("attachment key is required")
+	}
+	if params.OrgID == "" {
+		return fmt.Errorf("org ID is required")
+	}
+	if params.Status == nil {
+		return fmt.Errorf("attachment status is required")
+	}
+
+	resp, err := a.client.POST(ctx, "/attachment/status", params)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return nil
+}

--- a/api/attachment/attachment_test.go
+++ b/api/attachment/attachment_test.go
@@ -1,0 +1,71 @@
+package attachment
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/braintrustdata/braintrust-sdk-go/internal/https"
+	"github.com/braintrustdata/braintrust-sdk-go/logger"
+)
+
+func TestRequestUploadURL(t *testing.T) {
+	var req map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/attachment", r.URL.Path)
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "Bearer api-key", r.Header.Get("Authorization"))
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"signedUrl": "https://object-store/upload",
+			"headers":   map[string]string{"X-Test": "yes"},
+		})
+	}))
+	defer server.Close()
+
+	api := New(https.NewClient("api-key", server.URL, logger.Discard()))
+	resp, err := api.RequestUploadURL(context.Background(), UploadURLParams{
+		Key:         "key-1",
+		Filename:    "input.json",
+		ContentType: "application/json",
+		OrgID:       "org-id",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "https://object-store/upload", resp.SignedURL)
+	require.Equal(t, "yes", resp.Headers["X-Test"])
+	require.Equal(t, "key-1", req["key"])
+	require.Equal(t, "input.json", req["filename"])
+	require.Equal(t, "application/json", req["content_type"])
+	require.Equal(t, "org-id", req["org_id"])
+}
+
+func TestUpdateStatus(t *testing.T) {
+	var req map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/attachment/status", r.URL.Path)
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "Bearer api-key", r.Header.Get("Authorization"))
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	api := New(https.NewClient("api-key", server.URL, logger.Discard()))
+	err := api.UpdateStatus(context.Background(), StatusParams{
+		Key:   "key-1",
+		OrgID: "org-id",
+		Status: map[string]any{
+			"upload_status": "done",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "key-1", req["key"])
+	require.Equal(t, "org-id", req["org_id"])
+	status, ok := req["status"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "done", status["upload_status"])
+}

--- a/api/attachment/types.go
+++ b/api/attachment/types.go
@@ -1,0 +1,22 @@
+package attachment
+
+// UploadURLParams requests a signed URL for an attachment upload.
+type UploadURLParams struct {
+	Key         string `json:"key"`
+	Filename    string `json:"filename"`
+	ContentType string `json:"content_type"`
+	OrgID       string `json:"org_id"`
+}
+
+// UploadURLResponse contains signed object-store upload details.
+type UploadURLResponse struct {
+	SignedURL string            `json:"signedUrl"`
+	Headers   map[string]string `json:"headers"`
+}
+
+// StatusParams updates attachment upload status.
+type StatusParams struct {
+	Key    string         `json:"key"`
+	OrgID  string         `json:"org_id"`
+	Status map[string]any `json:"status"`
+}

--- a/client.go
+++ b/client.go
@@ -2,17 +2,23 @@ package braintrust
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/trace"
 	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/google/uuid"
 
 	"github.com/braintrustdata/braintrust-sdk-go/api"
 	"github.com/braintrustdata/braintrust-sdk-go/config"
 	"github.com/braintrustdata/braintrust-sdk-go/eval"
+	internalattachment "github.com/braintrustdata/braintrust-sdk-go/internal/attachment"
 	"github.com/braintrustdata/braintrust-sdk-go/internal/auth"
 	"github.com/braintrustdata/braintrust-sdk-go/logger"
 	bttrace "github.com/braintrustdata/braintrust-sdk-go/trace"
+	bttraceattachment "github.com/braintrustdata/braintrust-sdk-go/trace/attachment"
 )
 
 // Client is the main Braintrust SDK client
@@ -21,6 +27,7 @@ type Client struct {
 	logger         logger.Logger
 	session        *auth.Session
 	tracerProvider *trace.TracerProvider
+	uploader       *internalattachment.LazyUploader
 }
 
 // New creates a new Braintrust client.
@@ -90,9 +97,12 @@ func New(tp *trace.TracerProvider, opts ...Option) (*Client, error) {
 
 	client.session = session
 	client.tracerProvider = tp
+	client.uploader = internalattachment.NewLazyUploader(session, log)
 
 	// Setup tracing with provided TracerProvider
 	if err := client.setupTracing(); err != nil {
+		_ = client.uploader.Shutdown(context.Background())
+		session.Close()
 		log.Error("failed to setup tracing", "error", err)
 		return nil, fmt.Errorf("failed to setup tracing: %w", err)
 	}
@@ -103,6 +113,8 @@ func New(tp *trace.TracerProvider, opts ...Option) (*Client, error) {
 		log.Debug("waiting for login to complete")
 		err := session.Login(context.Background())
 		if err != nil {
+			_ = client.uploader.Shutdown(context.Background())
+			session.Close()
 			log.Error("blocking login failed", "error", err)
 			return nil, fmt.Errorf("login failed: %w", err)
 		}
@@ -124,6 +136,7 @@ func (c *Client) setupTracing() error {
 		EnableTraceConsoleLog:  c.config.EnableTraceConsoleLog,
 		Exporter:               c.config.Exporter,
 		Logger:                 c.logger,
+		AttachmentUploader:     c.uploader,
 	}
 
 	// Add Braintrust span processor to the provided TracerProvider
@@ -189,6 +202,60 @@ func (c *Client) TracerProvider() *trace.TracerProvider {
 //	defer span.End()
 func (c *Client) Tracer(name string, opts ...oteltrace.TracerOption) oteltrace.Tracer {
 	return c.tracerProvider.Tracer(name, opts...)
+}
+
+// SetJSONAttachment serializes data as JSON, sets a Braintrust attachment reference on span,
+// and enqueues the attachment upload on this client.
+//
+// To attach JSON already encoded as bytes, pass json.RawMessage(data). Passing a
+// raw []byte directly will marshal it as a base64 JSON string.
+func (c *Client) SetJSONAttachment(ctx context.Context, span oteltrace.Span, key string, data any, opts ...bttraceattachment.JSONAttachmentOption) (*bttraceattachment.AttachmentReference, error) {
+	options := jsonAttachmentOptions("data.json", opts...)
+
+	var b []byte
+	var err error
+	if options.Pretty {
+		b, err = json.MarshalIndent(data, "", "  ")
+	} else {
+		b, err = json.Marshal(data)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal JSON attachment: %w", err)
+	}
+
+	return c.setJSONBytes(ctx, span, key, b, options.Filename)
+}
+
+func jsonAttachmentOptions(defaultFilename string, opts ...bttraceattachment.JSONAttachmentOption) bttraceattachment.JSONAttachmentOptions {
+	options := bttraceattachment.JSONAttachmentOptions{Filename: defaultFilename}
+	for _, opt := range opts {
+		opt(&options)
+	}
+	if options.Filename == "" {
+		options.Filename = defaultFilename
+	}
+	return options
+}
+
+func (c *Client) setJSONBytes(ctx context.Context, span oteltrace.Span, key string, data []byte, filename string) (*bttraceattachment.AttachmentReference, error) {
+	ref := bttraceattachment.AttachmentReference{
+		Type:        "braintrust_attachment",
+		Filename:    filename,
+		ContentType: bttraceattachment.JSON,
+		Key:         uuid.NewString(),
+	}
+
+	refJSON, err := json.Marshal(ref)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal attachment reference: %w", err)
+	}
+
+	if err := c.uploader.Enqueue(ctx, internalattachment.Upload{Reference: ref, Data: data}); err != nil {
+		return nil, err
+	}
+
+	span.SetAttributes(attribute.String(key, string(refJSON)))
+	return &ref, nil
 }
 
 // NewEvaluator creates a new evaluator for running multiple evaluations with the same

--- a/client_test.go
+++ b/client_test.go
@@ -2,6 +2,9 @@ package braintrust
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -72,6 +75,32 @@ func TestNew_WithBlockingLogin(t *testing.T) {
 	str := client.String()
 	assert.Contains(t, str, "test-org-name")
 	assert.Contains(t, str, "test-org-id")
+}
+
+func TestNew_WithBlockingLoginFailureShutsDownUploader(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/apikey/login":
+			http.Error(w, "nope", http.StatusUnauthorized)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	tp := trace.NewTracerProvider()
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	client, err := New(tp,
+		WithAPIKey("bad-key"),
+		WithProject("test-project"),
+		WithAppURL(server.URL),
+		WithAPIURL(server.URL),
+		WithBlockingLogin(true),
+		WithLogger(logger.Discard()),
+	)
+	require.Error(t, err)
+	require.Nil(t, client)
 }
 
 func TestNew_MissingAPIKey(t *testing.T) {
@@ -175,6 +204,63 @@ func TestTracing_EndToEnd(t *testing.T) {
 	// Verify span was captured by our exporter
 	spans := exporter.GetSpans()
 	assert.GreaterOrEqual(t, len(spans), 1, "Expected at least one span to be exported")
+}
+
+func TestClientSetJSONUploadsAttachment(t *testing.T) {
+	var statusReq map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/apikey/login":
+			require.Equal(t, http.MethodPost, r.Method)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"org_info": []map[string]any{{
+					"id":        "org-id",
+					"name":      "org-name",
+					"api_url":   "http://" + r.Host,
+					"proxy_url": "http://" + r.Host,
+				}},
+			})
+		case "/attachment":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"signedUrl": "http://" + r.Host + "/upload",
+				"headers":   map[string]string{},
+			})
+		case "/upload":
+			w.WriteHeader(http.StatusOK)
+		case "/attachment/status":
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&statusReq))
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	exporter := tracetest.NewInMemoryExporter()
+	tp := trace.NewTracerProvider()
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	client, err := New(tp,
+		WithAPIKey("api-key"),
+		WithProject("test-project"),
+		WithAppURL(server.URL),
+		WithAPIURL(server.URL),
+		WithExporter(exporter),
+		WithBlockingLogin(true),
+		WithLogger(logger.Discard()),
+	)
+	require.NoError(t, err)
+
+	ctx, span := tp.Tracer("raw-tracer").Start(context.Background(), "span")
+	_, err = client.SetJSONAttachment(ctx, span, "braintrust.input_json", map[string]any{"hello": "world"})
+	require.NoError(t, err)
+	span.End()
+
+	require.NoError(t, tp.ForceFlush(context.Background()))
+	require.NotNil(t, statusReq)
+	status, ok := statusReq["status"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "done", status["upload_status"])
 }
 
 func TestTracing_WithExporter(t *testing.T) {

--- a/examples/attachments/main.go
+++ b/examples/attachments/main.go
@@ -41,7 +41,7 @@ func main() {
 		log.Fatalf("Failed to initialize Braintrust: %v", err)
 	}
 
-	tracer := otel.Tracer("attachments-example")
+	tracer := bt.Tracer("attachments-example")
 	ctx := context.Background()
 
 	// Create a parent span to wrap all examples
@@ -66,6 +66,10 @@ func main() {
 	// Example 5: Use attachment in manual span logging
 	fmt.Println("\nExample 5: Manual span with attachment")
 	exampleManualSpan(ctx, tracer)
+
+	// Example 6: Background-uploaded JSON attachment reference
+	fmt.Println("\nExample 6: JSON attachment")
+	exampleJSONAttachment(ctx, bt, tracer)
 
 	// End the main span
 	span.End()
@@ -254,6 +258,24 @@ func logAttachment(span oteltrace.Span, att *attachment.Attachment) error {
 	messagesJSON, _ := json.Marshal(messages)
 	span.SetAttributes(attribute.String("braintrust.input_json", string(messagesJSON)))
 	return nil
+}
+
+func exampleJSONAttachment(ctx context.Context, bt *braintrust.Client, tracer oteltrace.Tracer) {
+	_, span := tracer.Start(ctx, "attachment.json")
+	defer span.End()
+
+	transcript := []map[string]string{
+		{"role": "user", "content": "Summarize this conversation."},
+		{"role": "assistant", "content": "Sure — upload the transcript as JSON."},
+	}
+
+	_, err := bt.SetJSONAttachment(ctx, span, "braintrust.input_json", transcript,
+		attachment.WithFilename("conversation_transcript.json"),
+		attachment.WithPrettyJSON(),
+	)
+	if err != nil {
+		log.Printf("Failed to create JSON attachment: %v", err)
+	}
 }
 
 // createTestImage creates a temporary 10x10 PNG image for testing

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.4
 toolchain go1.26.1
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.35.0
@@ -21,7 +22,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/internal/attachment/lazy_uploader.go
+++ b/internal/attachment/lazy_uploader.go
@@ -1,0 +1,70 @@
+// Package attachment uploads Braintrust attachment payloads in the background.
+package attachment
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/braintrustdata/braintrust-sdk-go/internal/auth"
+	"github.com/braintrustdata/braintrust-sdk-go/logger"
+)
+
+// LazyUploader starts an Uploader on first enqueue.
+type LazyUploader struct {
+	session *auth.Session
+	logger  logger.Logger
+
+	mu       sync.Mutex
+	uploader *Uploader
+	closed   bool
+}
+
+// NewLazyUploader creates an uploader that starts its worker on first enqueue.
+func NewLazyUploader(session *auth.Session, log logger.Logger) *LazyUploader {
+	return &LazyUploader{session: session, logger: log}
+}
+
+func (u *LazyUploader) get() (*Uploader, error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	if u.closed {
+		return nil, fmt.Errorf("attachment uploader is shut down")
+	}
+	if u.uploader == nil {
+		u.uploader = NewUploader(u.session, u.logger)
+	}
+	return u.uploader, nil
+}
+
+// Enqueue schedules an attachment upload, creating the underlying uploader if needed.
+func (u *LazyUploader) Enqueue(ctx context.Context, upload Upload) error {
+	uploader, err := u.get()
+	if err != nil {
+		return err
+	}
+	return uploader.Enqueue(ctx, upload)
+}
+
+// ForceFlush waits for currently pending uploads to complete.
+func (u *LazyUploader) ForceFlush(ctx context.Context) error {
+	u.mu.Lock()
+	uploader := u.uploader
+	u.mu.Unlock()
+	if uploader == nil {
+		return nil
+	}
+	return uploader.ForceFlush(ctx)
+}
+
+// Shutdown prevents future uploads and waits for pending uploads to complete.
+func (u *LazyUploader) Shutdown(ctx context.Context) error {
+	u.mu.Lock()
+	uploader := u.uploader
+	u.closed = true
+	u.mu.Unlock()
+	if uploader == nil {
+		return nil
+	}
+	return uploader.Shutdown(ctx)
+}

--- a/internal/attachment/types.go
+++ b/internal/attachment/types.go
@@ -1,0 +1,24 @@
+package attachment
+
+import "context"
+
+// Reference is the JSON object stored on a span in place of uploaded attachment data.
+type Reference struct {
+	Type        string `json:"type"`
+	Filename    string `json:"filename"`
+	ContentType string `json:"content_type"`
+	Key         string `json:"key"`
+}
+
+// Upload is a pending uploaded attachment.
+type Upload struct {
+	Reference Reference
+	Data      []byte
+}
+
+// SpanUploader uploads attachments and tracks pending work for flush/shutdown.
+type SpanUploader interface {
+	Enqueue(ctx context.Context, upload Upload) error
+	ForceFlush(ctx context.Context) error
+	Shutdown(ctx context.Context) error
+}

--- a/internal/attachment/uploader.go
+++ b/internal/attachment/uploader.go
@@ -1,0 +1,297 @@
+package attachment
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	apiattachment "github.com/braintrustdata/braintrust-sdk-go/api/attachment"
+	"github.com/braintrustdata/braintrust-sdk-go/internal/auth"
+	"github.com/braintrustdata/braintrust-sdk-go/internal/https"
+	"github.com/braintrustdata/braintrust-sdk-go/logger"
+)
+
+const defaultQueueSize = 1000
+
+type uploadJob struct {
+	ctx    context.Context
+	upload Upload
+	batch  *uploadBatch
+}
+
+type uploadBatch struct {
+	pending int
+	idle    chan struct{}
+}
+
+// Uploader manages background attachment uploads for a Braintrust session.
+type Uploader struct {
+	session    *auth.Session
+	logger     logger.Logger
+	ctx        context.Context
+	cancel     context.CancelFunc
+	queue      chan uploadJob
+	done       chan struct{}
+	workerDone chan struct{}
+	once       sync.Once
+
+	mu            sync.Mutex
+	batch         *uploadBatch
+	err           error
+	closed        bool
+	client        *https.Client
+	attachmentAPI *apiattachment.API
+}
+
+// NewUploader starts a background worker for attachment uploads.
+func NewUploader(session *auth.Session, log logger.Logger) *Uploader {
+	if log == nil {
+		log = logger.Discard()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	u := &Uploader{
+		session:    session,
+		logger:     log,
+		ctx:        ctx,
+		cancel:     cancel,
+		queue:      make(chan uploadJob, defaultQueueSize),
+		done:       make(chan struct{}),
+		workerDone: make(chan struct{}),
+	}
+	go u.worker()
+	return u
+}
+
+func (u *Uploader) uploadContext(ctx context.Context) context.Context {
+	return uploaderContext{Context: context.WithoutCancel(ctx), done: u.ctx.Done()}
+}
+
+type uploaderContext struct {
+	context.Context
+	done <-chan struct{}
+}
+
+func (c uploaderContext) Done() <-chan struct{} { return c.done }
+
+func (c uploaderContext) Err() error {
+	select {
+	case <-c.done:
+		return context.Canceled
+	default:
+		return nil
+	}
+}
+
+// Enqueue schedules an attachment upload.
+func (u *Uploader) Enqueue(ctx context.Context, upload Upload) error {
+	u.mu.Lock()
+	if u.closed {
+		u.mu.Unlock()
+		return fmt.Errorf("attachment uploader is shut down")
+	}
+	if u.batch == nil {
+		u.batch = &uploadBatch{idle: make(chan struct{})}
+	}
+	batch := u.batch
+	batch.pending++
+	u.mu.Unlock()
+
+	select {
+	case u.queue <- uploadJob{ctx: u.uploadContext(ctx), upload: upload, batch: batch}:
+		return nil
+	default:
+		u.finishPending(batch)
+		return fmt.Errorf("attachment upload queue is full")
+	}
+}
+
+// ForceFlush waits for all uploads enqueued before the call to complete.
+func (u *Uploader) ForceFlush(ctx context.Context) error {
+	u.mu.Lock()
+	batch := u.batch
+	u.mu.Unlock()
+	if batch == nil {
+		return u.takeErr()
+	}
+
+	select {
+	case <-batch.idle:
+		return u.takeErr()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (u *Uploader) worker() {
+	defer close(u.workerDone)
+	for {
+		select {
+		case job := <-u.queue:
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						u.logger.Error("attachment upload panic", "key", job.upload.Reference.Key, "panic", r)
+					}
+					u.finishPending(job.batch)
+				}()
+				if err := u.upload(job.ctx, job.upload); err != nil {
+					u.recordError(err)
+					u.logger.Warn("failed to upload attachment", "key", job.upload.Reference.Key, "error", err)
+				}
+			}()
+		case <-u.done:
+			u.discardQueued()
+			return
+		}
+	}
+}
+
+func (u *Uploader) discardQueued() {
+	for {
+		select {
+		case job := <-u.queue:
+			u.finishPending(job.batch)
+		default:
+			return
+		}
+	}
+}
+
+func (u *Uploader) recordError(err error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.err = errors.Join(u.err, err)
+}
+
+func (u *Uploader) takeErr() error {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	err := u.err
+	u.err = nil
+	return err
+}
+
+func (u *Uploader) finishPending(batch *uploadBatch) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	batch.pending--
+	if batch.pending == 0 {
+		close(batch.idle)
+		if u.batch == batch {
+			u.batch = nil
+		}
+	}
+}
+
+// Shutdown stops accepting uploads and shuts down the background worker.
+func (u *Uploader) Shutdown(ctx context.Context) error {
+	u.mu.Lock()
+	u.closed = true
+	u.mu.Unlock()
+	flushErr := u.ForceFlush(ctx)
+	u.once.Do(func() {
+		u.cancel()
+		close(u.done)
+	})
+
+	select {
+	case <-u.workerDone:
+		return flushErr
+	case <-ctx.Done():
+		return errors.Join(flushErr, ctx.Err())
+	}
+}
+
+func (u *Uploader) upload(ctx context.Context, upload Upload) error {
+	if err := u.session.Login(ctx); err != nil {
+		return fmt.Errorf("failed to login before attachment upload: %w", err)
+	}
+
+	attachmentAPI, client, orgID := u.attachmentClient()
+
+	status := map[string]any{"upload_status": "done"}
+	if err := u.doUpload(ctx, attachmentAPI, client, orgID, upload); err != nil {
+		status["upload_status"] = "error"
+		status["error_message"] = err.Error()
+		if statusErr := u.postStatus(ctx, attachmentAPI, orgID, upload.Reference.Key, status); statusErr != nil {
+			return fmt.Errorf("%w; additionally failed to log attachment status: %v", err, statusErr)
+		}
+		return err
+	}
+
+	if err := u.postStatus(ctx, attachmentAPI, orgID, upload.Reference.Key, status); err != nil {
+		return fmt.Errorf("failed to log attachment status: %w", err)
+	}
+	return nil
+}
+
+func (u *Uploader) attachmentClient() (*apiattachment.API, *https.Client, string) {
+	apiInfo := u.session.APIInfo()
+	orgInfo := u.session.OrgInfo()
+
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	if u.client == nil {
+		u.client = https.NewClient(apiInfo.APIKey, apiInfo.APIURL, u.logger)
+		u.attachmentAPI = apiattachment.New(u.client)
+	}
+	return u.attachmentAPI, u.client, orgInfo.ID
+}
+
+func (u *Uploader) doUpload(ctx context.Context, attachmentAPI *apiattachment.API, client *https.Client, orgID string, upload Upload) error {
+	metadata, err := attachmentAPI.RequestUploadURL(ctx, apiattachment.UploadURLParams{
+		Key:         upload.Reference.Key,
+		Filename:    upload.Reference.Filename,
+		ContentType: upload.Reference.ContentType,
+		OrgID:       orgID,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to request signed URL: %w", err)
+	}
+
+	putReq, err := http.NewRequestWithContext(ctx, http.MethodPut, metadata.SignedURL, bytes.NewReader(upload.Data))
+	if err != nil {
+		return fmt.Errorf("failed to create object store request: %w", err)
+	}
+	addAzureBlobHeaders(metadata.Headers, metadata.SignedURL)
+	for k, v := range metadata.Headers {
+		putReq.Header.Set(k, v)
+	}
+
+	putResp, err := client.Client().Do(putReq)
+	if err != nil {
+		return fmt.Errorf("failed to upload attachment to object store: %w", err)
+	}
+	defer func() { _ = putResp.Body.Close() }()
+	if putResp.StatusCode < 200 || putResp.StatusCode >= 300 {
+		body, _ := io.ReadAll(putResp.Body)
+		return fmt.Errorf("failed to upload attachment to object store: status %d body %s", putResp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+func addAzureBlobHeaders(headers map[string]string, signedURL string) {
+	u, err := url.Parse(signedURL)
+	if err != nil {
+		return
+	}
+	host := u.Hostname()
+	if host == "blob.core.windows.net" || strings.HasSuffix(host, ".blob.core.windows.net") {
+		headers["x-ms-blob-type"] = "BlockBlob"
+	}
+}
+
+func (u *Uploader) postStatus(ctx context.Context, attachmentAPI *apiattachment.API, orgID string, key string, status map[string]any) error {
+	return attachmentAPI.UpdateStatus(ctx, apiattachment.StatusParams{
+		Key:    key,
+		OrgID:  orgID,
+		Status: status,
+	})
+}

--- a/internal/attachment/uploader_test.go
+++ b/internal/attachment/uploader_test.go
@@ -1,0 +1,295 @@
+package attachment
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/braintrustdata/braintrust-sdk-go/internal/auth"
+	"github.com/braintrustdata/braintrust-sdk-go/logger"
+)
+
+func TestAttachmentUploaderUploadsAndReportsDone(t *testing.T) {
+	var mu sync.Mutex
+	var metadataReq map[string]any
+	var statusReq map[string]any
+	var putBody string
+	var putHeader string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/attachment":
+			require.Equal(t, http.MethodPost, r.Method)
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&metadataReq))
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"signedUrl": "http://" + r.Host + "/upload",
+				"headers":   map[string]string{"X-Test": "yes"},
+			})
+		case "/upload":
+			require.Equal(t, http.MethodPut, r.Method)
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			mu.Lock()
+			putBody = string(body)
+			putHeader = r.Header.Get("X-Test")
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		case "/attachment/status":
+			require.Equal(t, http.MethodPost, r.Method)
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&statusReq))
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	session := auth.NewTestSession("api-key", "org-id", "org-name", server.URL, server.URL, server.URL, logger.Discard())
+	uploader := NewUploader(session, logger.Discard())
+
+	ref := Reference{Type: "braintrust_attachment", Filename: "input.json", ContentType: "application/json", Key: "key-1"}
+	require.NoError(t, uploader.Enqueue(context.Background(), Upload{Reference: ref, Data: []byte(`{"hello":"world"}`)}))
+	require.NoError(t, uploader.ForceFlush(context.Background()))
+
+	require.Equal(t, map[string]any{
+		"key":          "key-1",
+		"filename":     "input.json",
+		"content_type": "application/json",
+		"org_id":       "org-id",
+	}, metadataReq)
+
+	mu.Lock()
+	require.Equal(t, `{"hello":"world"}`, putBody)
+	require.Equal(t, "yes", putHeader)
+	mu.Unlock()
+
+	require.Equal(t, "key-1", statusReq["key"])
+	require.Equal(t, "org-id", statusReq["org_id"])
+	status, ok := statusReq["status"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "done", status["upload_status"])
+}
+
+func TestAttachmentUploaderReusesHTTPClient(t *testing.T) {
+	var connMu sync.Mutex
+	newConnections := 0
+	statusCount := 0
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/attachment":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"signedUrl": "http://" + r.Host + "/upload",
+				"headers":   map[string]string{},
+			})
+		case "/upload":
+			w.WriteHeader(http.StatusOK)
+		case "/attachment/status":
+			connMu.Lock()
+			statusCount++
+			connMu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			connMu.Lock()
+			newConnections++
+			connMu.Unlock()
+		}
+	}
+	server.Start()
+	defer server.Close()
+
+	session := auth.NewTestSession("api-key", "org-id", "org-name", server.URL, server.URL, server.URL, logger.Discard())
+	uploader := NewUploader(session, logger.Discard())
+
+	for _, key := range []string{"key-1", "key-2"} {
+		ref := Reference{Type: "braintrust_attachment", Filename: "input.json", ContentType: "application/json", Key: key}
+		require.NoError(t, uploader.Enqueue(context.Background(), Upload{Reference: ref, Data: []byte(`{"hello":"world"}`)}))
+	}
+	require.NoError(t, uploader.ForceFlush(context.Background()))
+
+	connMu.Lock()
+	require.Equal(t, 2, statusCount)
+	require.Equal(t, 1, newConnections)
+	connMu.Unlock()
+}
+
+func TestAddAzureBlobHeaders(t *testing.T) {
+	headers := map[string]string{}
+	addAzureBlobHeaders(headers, "https://acct.blob.core.windows.net/container/blob?sas=1")
+	require.Equal(t, "BlockBlob", headers["x-ms-blob-type"])
+
+	headers = map[string]string{}
+	addAzureBlobHeaders(headers, "https://blob.core.windows.net/container/blob?sas=1")
+	require.Equal(t, "BlockBlob", headers["x-ms-blob-type"])
+
+	headers = map[string]string{}
+	addAzureBlobHeaders(headers, "https://example.com/upload?redirect=blob.core.windows.net")
+	require.Empty(t, headers)
+
+	headers = map[string]string{}
+	addAzureBlobHeaders(headers, "https://notblob.core.windows.net.example.com/upload")
+	require.Empty(t, headers)
+}
+
+func TestAttachmentUploaderRecoversFromUploadPanic(t *testing.T) {
+	uploader := NewUploader(nil, logger.Discard())
+
+	ref := Reference{Type: "braintrust_attachment", Filename: "input.json", ContentType: "application/json", Key: "key-1"}
+	require.NoError(t, uploader.Enqueue(context.Background(), Upload{Reference: ref, Data: []byte(`{"hello":"world"}`)}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, uploader.ForceFlush(ctx))
+}
+
+func TestAttachmentUploaderShutdownCancelsBlockingLogin(t *testing.T) {
+	unblockLogin := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/apikey/login":
+			select {
+			case <-unblockLogin:
+			case <-r.Context().Done():
+			}
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	defer close(unblockLogin)
+
+	session, err := auth.NewSession(context.Background(), auth.Options{
+		APIKey: "api-key",
+		AppURL: server.URL,
+		APIURL: server.URL,
+		Logger: logger.Discard(),
+	})
+	require.NoError(t, err)
+	defer session.Close()
+
+	uploader := NewUploader(session, logger.Discard())
+	ref := Reference{Type: "braintrust_attachment", Filename: "input.json", ContentType: "application/json", Key: "key-1"}
+	require.NoError(t, uploader.Enqueue(context.Background(), Upload{Reference: ref, Data: []byte(`{"hello":"world"}`)}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, uploader.Shutdown(ctx), context.DeadlineExceeded)
+	require.Eventually(t, func() bool {
+		select {
+		case <-uploader.workerDone:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestAttachmentUploaderShutdownWaitsForWorkerExit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/attachment":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"signedUrl": "http://" + r.Host + "/upload",
+				"headers":   map[string]string{},
+			})
+		case "/upload":
+			w.WriteHeader(http.StatusOK)
+		case "/attachment/status":
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	session := auth.NewTestSession("api-key", "org-id", "org-name", server.URL, server.URL, server.URL, logger.Discard())
+	uploader := NewUploader(session, logger.Discard())
+
+	ref := Reference{Type: "braintrust_attachment", Filename: "input.json", ContentType: "application/json", Key: "key-1"}
+	require.NoError(t, uploader.Enqueue(context.Background(), Upload{Reference: ref, Data: []byte(`{"hello":"world"}`)}))
+	require.NoError(t, uploader.Shutdown(context.Background()))
+
+	select {
+	case <-uploader.workerDone:
+	default:
+		t.Fatal("Shutdown returned before attachment uploader worker exited")
+	}
+}
+
+func TestAttachmentUploaderShutdownReportsStatusError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/attachment":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"signedUrl": "http://" + r.Host + "/upload",
+				"headers":   map[string]string{},
+			})
+		case "/upload":
+			w.WriteHeader(http.StatusOK)
+		case "/attachment/status":
+			http.Error(w, "nope", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	session := auth.NewTestSession("api-key", "org-id", "org-name", server.URL, server.URL, server.URL, logger.Discard())
+	uploader := NewUploader(session, logger.Discard())
+
+	ref := Reference{Type: "braintrust_attachment", Filename: "input.json", ContentType: "application/json", Key: "key-1"}
+	require.NoError(t, uploader.Enqueue(context.Background(), Upload{Reference: ref, Data: []byte(`{"hello":"world"}`)}))
+	err := uploader.Shutdown(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to log attachment status")
+}
+
+func TestAttachmentUploaderReportsError(t *testing.T) {
+	var statusReq map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/attachment":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"signedUrl": "http://" + r.Host + "/upload",
+				"headers":   map[string]string{},
+			})
+		case "/upload":
+			w.WriteHeader(http.StatusInternalServerError)
+		case "/attachment/status":
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&statusReq))
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	session := auth.NewTestSession("api-key", "org-id", "org-name", server.URL, server.URL, server.URL, logger.Discard())
+	uploader := NewUploader(session, logger.Discard())
+
+	ref := Reference{Type: "braintrust_attachment", Filename: "input.json", ContentType: "application/json", Key: "key-1"}
+	require.NoError(t, uploader.Enqueue(context.Background(), Upload{Reference: ref, Data: []byte(`{"hello":"world"}`)}))
+	err := uploader.ForceFlush(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to upload attachment to object store")
+
+	status, ok := statusReq["status"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "error", status["upload_status"])
+	require.NotEmpty(t, status["error_message"])
+}

--- a/trace/attachment/json.go
+++ b/trace/attachment/json.go
@@ -1,0 +1,35 @@
+package attachment
+
+import internalattachment "github.com/braintrustdata/braintrust-sdk-go/internal/attachment"
+
+// JSON is the MIME type for JSON attachments.
+const JSON = "application/json"
+
+// JSONAttachmentOption configures JSON attachment creation.
+type JSONAttachmentOption func(*JSONAttachmentOptions)
+
+// JSONAttachmentOptions holds configuration for JSON attachments.
+type JSONAttachmentOptions struct {
+	Filename string
+	Pretty   bool
+}
+
+// WithFilename sets the display filename for the attachment.
+func WithFilename(filename string) JSONAttachmentOption {
+	return func(o *JSONAttachmentOptions) {
+		o.Filename = filename
+	}
+}
+
+// WithPrettyJSON pretty-prints JSON attachment contents with two-space indentation.
+func WithPrettyJSON() JSONAttachmentOption {
+	return func(o *JSONAttachmentOptions) {
+		o.Pretty = true
+	}
+}
+
+// AttachmentReference is the JSON object stored on a span in place of uploaded attachment data.
+// Its shape intentionally matches Python/JavaScript Braintrust attachment references.
+//
+//revive:disable-next-line:exported This public name matches the cross-SDK attachment API.
+type AttachmentReference = internalattachment.Reference

--- a/trace/attachment/json_test.go
+++ b/trace/attachment/json_test.go
@@ -1,0 +1,16 @@
+package attachment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONAttachmentOptions(t *testing.T) {
+	options := JSONAttachmentOptions{}
+	WithFilename("input.json")(&options)
+	WithPrettyJSON()(&options)
+
+	require.Equal(t, "input.json", options.Filename)
+	require.True(t, options.Pretty)
+}

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -26,6 +26,7 @@ package trace
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -62,6 +63,15 @@ type Config struct {
 
 	// Logger
 	Logger logger.Logger
+
+	// AttachmentUploader flushes/shuts down attachment uploads owned by this processor.
+	AttachmentUploader AttachmentUploader
+}
+
+// AttachmentUploader tracks pending attachment uploads for span processor flush/shutdown.
+type AttachmentUploader interface {
+	ForceFlush(ctx context.Context) error
+	Shutdown(ctx context.Context) error
 }
 
 // SpanFilterFunc decides which spans to send to Braintrust.
@@ -130,6 +140,7 @@ func GetSpanProcessor(session *auth.Session, cfg Config) (sdktrace.SpanProcessor
 		rootFilters,
 		session,
 		log,
+		cfg.AttachmentUploader,
 	)
 	if err != nil {
 		return nil, err
@@ -343,12 +354,13 @@ func (o *otelAttrs) makeAttrs() {
 }
 
 type spanProcessor struct {
-	wrapped     sdktrace.SpanProcessor
-	filters     []SpanFilterFunc
-	rootFilters []SpanFilterFunc
-	otelAttrs   *otelAttrs
-	session     *auth.Session // Session provides endpoints and org name
-	logger      logger.Logger
+	wrapped            sdktrace.SpanProcessor
+	filters            []SpanFilterFunc
+	rootFilters        []SpanFilterFunc
+	otelAttrs          *otelAttrs
+	session            *auth.Session // Session provides endpoints and org name
+	logger             logger.Logger
+	attachmentUploader AttachmentUploader
 }
 
 // newSpanProcessor creates a new span processor that wraps another processor and adds parent labeling.
@@ -359,6 +371,7 @@ func newSpanProcessor(
 	rootFilters []SpanFilterFunc,
 	session *auth.Session,
 	log logger.Logger,
+	attachmentUploader AttachmentUploader,
 ) (*spanProcessor, error) {
 	// Get app URL from session
 	appURL := session.AppPublicURL()
@@ -367,12 +380,13 @@ func newSpanProcessor(
 	attrs := newOtelAttrs(defaultParent, "", appURL)
 
 	sp := &spanProcessor{
-		wrapped:     proc,
-		filters:     filters,
-		rootFilters: rootFilters,
-		otelAttrs:   attrs,
-		session:     session,
-		logger:      log,
+		wrapped:            proc,
+		filters:            filters,
+		rootFilters:        rootFilters,
+		otelAttrs:          attrs,
+		session:            session,
+		logger:             log,
+		attachmentUploader: attachmentUploader,
 	}
 
 	return sp, nil
@@ -454,12 +468,32 @@ func (sp *spanProcessor) shouldForwardSpan(span sdktrace.ReadOnlySpan) bool {
 
 // Shutdown shuts down the span processor.
 func (sp *spanProcessor) Shutdown(ctx context.Context) error {
-	return sp.wrapped.Shutdown(ctx)
+	return errors.Join(
+		sp.wrapped.Shutdown(ctx),
+		sp.shutdownAttachments(ctx),
+	)
+}
+
+func (sp *spanProcessor) shutdownAttachments(ctx context.Context) error {
+	if sp.attachmentUploader == nil {
+		return nil
+	}
+	return sp.attachmentUploader.Shutdown(ctx)
 }
 
 // ForceFlush forces a flush of the span processor.
 func (sp *spanProcessor) ForceFlush(ctx context.Context) error {
-	return sp.wrapped.ForceFlush(ctx)
+	return errors.Join(
+		sp.wrapped.ForceFlush(ctx),
+		sp.flushAttachments(ctx),
+	)
+}
+
+func (sp *spanProcessor) flushAttachments(ctx context.Context) error {
+	if sp.attachmentUploader == nil {
+		return nil
+	}
+	return sp.attachmentUploader.ForceFlush(ctx)
 }
 
 var _ sdktrace.SpanProcessor = &spanProcessor{}


### PR DESCRIPTION
Add a public JSON attachment API that serializes JSON, stores an attachment reference on an OpenTelemetry span, and uploads the JSON payload in the background. The upload queue is owned by the Braintrust client and is flushed or shut down with the configured tracer provider/span processor.

New public API:

Initialize Braintrust with a tracer provider and the normal client options:

```go
tp := sdktrace.NewTracerProvider()
defer tp.Shutdown(context.Background())

bt, err := braintrust.New(tp,
    braintrust.WithAPIKey(os.Getenv("BRAINTRUST_API_KEY")),
    braintrust.WithProject("my-project"),
)
if err != nil {
    log.Fatal(err)
}

tracer := bt.Tracer("my-app")
```

Send a JSON attachment by starting a span and passing that span to the client:

```go
ctx, span := tracer.Start(context.Background(), "example")
defer span.End()

_, err = bt.SetJSONAttachment(ctx, span, "braintrust.input_json", map[string]any{
    "messages": []map[string]string{
        {"role": "user", "content": "Summarize this conversation."},
    },
},
    attachment.WithFilename("conversation.json"),
    attachment.WithPrettyJSON(),
)
if err != nil {
    log.Fatal(err)
}
```