### PR TITLE
Add span attachment helper

### DIFF
--- a/examples/attachments/main.go
+++ b/examples/attachments/main.go
@@ -63,8 +63,12 @@ func main() {
 	fmt.Println("\nExample 4: FromURL")
 	exampleFromURL(ctx, tracer)
 
-	// Example 5: Use attachment in manual span logging
-	fmt.Println("\nExample 5: Manual span with attachment")
+	// Example 5: Create a JSON attachment
+	fmt.Println("\nExample 5: JSON attachment")
+	exampleJSONAttachment(ctx, tracer)
+
+	// Example 6: Use attachment in manual span logging
+	fmt.Println("\nExample 6: Manual span with attachment")
 	exampleManualSpan(ctx, tracer)
 
 	// End the main span
@@ -174,6 +178,33 @@ func exampleFromURL(ctx context.Context, tracer oteltrace.Tracer) {
 	err = logAttachment(span, att)
 	if err != nil {
 		log.Printf("Failed to log attachment: %v", err)
+	}
+}
+
+func exampleJSONAttachment(ctx context.Context, tracer oteltrace.Tracer) {
+	_, span := tracer.Start(ctx, "attachment.json")
+	defer span.End()
+
+	payload := map[string]interface{}{
+		"kind": "example-json-attachment",
+		"items": []map[string]interface{}{
+			{"id": 1, "label": "first"},
+			{"id": 2, "label": "second"},
+		},
+		"metadata": map[string]interface{}{
+			"source": "examples/attachments/main.go",
+		},
+	}
+
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		log.Printf("Failed to marshal JSON attachment: %v", err)
+		return
+	}
+
+	att := attachment.FromBytes("application/json", data)
+	if err := logAttachment(span, att); err != nil {
+		log.Printf("Failed to log JSON attachment: %v", err)
 	}
 }
 

--- a/examples/internal/kitchensink/main.go
+++ b/examples/internal/kitchensink/main.go
@@ -225,24 +225,12 @@ func runAttachmentDemos(ctx context.Context, tracer oteltrace.Tracer) {
 		imageBytes := getTestImageBytes()
 		att := attachment.FromBytes(attachment.ImagePNG, imageBytes)
 
-		// Log attachment in a manual span
-		attMsg, err := att.Base64Message()
-		if err != nil {
-			log.Printf("Failed to create attachment message: %v", err)
+		// Log attachment as a top-level span attribute.
+		if err := attachment.SetAttachmentOnSpan(span, "demo.image", att); err != nil {
+			log.Printf("Failed to set attachment on span: %v", err)
 			return
 		}
-
-		messages := []map[string]interface{}{
-			{
-				"role": "user",
-				"content": []interface{}{
-					map[string]interface{}{"type": "text", "text": "Test image from bytes"},
-					attMsg,
-				},
-			},
-		}
-		messagesJSON, _ := json.Marshal(messages)
-		span.SetAttributes(attribute.String("braintrust.input_json", string(messagesJSON)))
+		span.SetAttributes(attribute.String("braintrust.input_json", `{"prompt":"Test image from bytes","attachment_attr":"demo.image"}`))
 		span.SetAttributes(attribute.String("braintrust.output_json", `{"response": "Image received"}`))
 
 		fmt.Printf("     Created attachment from bytes (%d bytes)\n", len(imageBytes))

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.4
 toolchain go1.26.1
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.35.0
@@ -21,7 +22,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/trace/attachment/attachment.go
+++ b/trace/attachment/attachment.go
@@ -20,10 +20,14 @@ package attachment
 import (
 	"bytes"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Common MIME types for attachments
@@ -124,6 +128,40 @@ func (a *Attachment) Base64URL() (string, error) {
 	}
 
 	return buf.String(), nil
+}
+
+// attachmentDataAttrPrefix is the private OpenTelemetry attribute prefix used
+// to carry inline attachment data until the Braintrust span processor rewrites
+// it into a public attachment reference.
+const attachmentDataAttrPrefix = "braintrust.attachment.data."
+
+// SetAttachmentOnSpan records an attachment on span under key.
+//
+// The attachment is uploaded by the Braintrust span processor when the span is
+// exported. The private inline data attribute is removed before export and key
+// is exported as a Braintrust attachment reference.
+func SetAttachmentOnSpan(span trace.Span, key string, attachment *Attachment) error {
+	if key == "" {
+		return fmt.Errorf("attachment key cannot be empty")
+	}
+	if attachment == nil {
+		return fmt.Errorf("attachment cannot be nil")
+	}
+
+	msg, err := attachment.Base64Message()
+	if err != nil {
+		return err
+	}
+	b, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal attachment data: %w", err)
+	}
+
+	span.SetAttributes(
+		attribute.String(key, `{"type":"braintrust_attachment_pending"}`),
+		attribute.String(attachmentDataAttrPrefix+key, string(b)),
+	)
+	return nil
 }
 
 // Base64Message returns the attachment in message format for AI providers.

--- a/trace/attachment/attachment_test.go
+++ b/trace/attachment/attachment_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Test the new reader-based Attachment API
 func TestAttachment_NewAPI_FromBytes(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/trace/attachment/background.go
+++ b/trace/attachment/background.go
@@ -41,6 +41,8 @@ type uploadTask struct {
 	data []byte
 }
 
+// Uploader uploads span attachment data and rewrites private attachment
+// attributes into exported Braintrust attachment references.
 type Uploader struct {
 	session *auth.Session
 	logger  btlog.Logger
@@ -56,6 +58,7 @@ type Uploader struct {
 	inFlight int
 }
 
+// NewUploader creates and starts an attachment uploader for a Braintrust session.
 func NewUploader(session *auth.Session, log btlog.Logger) *Uploader {
 	if log == nil {
 		log = btlog.Discard()
@@ -73,6 +76,7 @@ func NewUploader(session *auth.Session, log btlog.Logger) *Uploader {
 	return u
 }
 
+// Start launches the background attachment upload workers.
 func (u *Uploader) Start() {
 	u.startOnce.Do(func() {
 		for i := 0; i < maxConcurrentUploads; i++ {
@@ -81,12 +85,14 @@ func (u *Uploader) Start() {
 	})
 }
 
+// Shutdown waits for queued uploads to finish and stops the uploader workers.
 func (u *Uploader) Shutdown(ctx context.Context) error {
 	err := u.Wait(ctx)
 	u.closeOnce.Do(func() { close(u.queue) })
 	return err
 }
 
+// Wait blocks until all in-flight attachment uploads complete.
 func (u *Uploader) Wait(ctx context.Context) error {
 	done, idle := u.doneChan()
 	if idle {
@@ -101,6 +107,8 @@ func (u *Uploader) Wait(ctx context.Context) error {
 	}
 }
 
+// ReplaceSpanAttachmentAttrs rewrites private attachment data attributes into
+// public Braintrust attachment reference attributes and queues uploads.
 func (u *Uploader) ReplaceSpanAttachmentAttrs(attrs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
 	var rewritten []attribute.KeyValue
 	changed := false
@@ -283,7 +291,7 @@ func (u *Uploader) upload(ctx context.Context, ref Reference, data []byte) error
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("signed URL request failed: %s", resp.Status)
 	}

--- a/trace/attachment/background.go
+++ b/trace/attachment/background.go
@@ -1,0 +1,317 @@
+package attachment
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/braintrustdata/braintrust-sdk-go/internal/auth"
+	btlog "github.com/braintrustdata/braintrust-sdk-go/logger"
+)
+
+// Reference is the JSON object stored in traces in place of inline attachment data.
+type Reference struct {
+	Type        string `json:"type"`
+	Filename    string `json:"filename"`
+	ContentType string `json:"content_type"`
+	Key         string `json:"key"`
+}
+
+// Uploader uploads inline base64 attachments in the background.
+const (
+	base64AttachmentType = "base64_attachment"
+	maxConcurrentUploads = 4
+	uploadQueueSize      = 30
+)
+
+type uploadTask struct {
+	ref  Reference
+	data []byte
+}
+
+type Uploader struct {
+	session *auth.Session
+	logger  btlog.Logger
+	client  *http.Client
+	queue   chan uploadTask
+
+	startOnce sync.Once
+	closeOnce sync.Once
+
+	mu       sync.Mutex
+	done     chan struct{}
+	errs     []error
+	inFlight int
+}
+
+func NewUploader(session *auth.Session, log btlog.Logger) *Uploader {
+	if log == nil {
+		log = btlog.Discard()
+	}
+	done := make(chan struct{})
+	close(done)
+	u := &Uploader{
+		session: session,
+		logger:  log,
+		client:  &http.Client{Timeout: 60 * time.Second},
+		queue:   make(chan uploadTask, uploadQueueSize),
+		done:    done,
+	}
+	u.Start()
+	return u
+}
+
+func (u *Uploader) Start() {
+	u.startOnce.Do(func() {
+		for i := 0; i < maxConcurrentUploads; i++ {
+			go u.worker()
+		}
+	})
+}
+
+func (u *Uploader) Shutdown(ctx context.Context) error {
+	err := u.Wait(ctx)
+	u.closeOnce.Do(func() { close(u.queue) })
+	return err
+}
+
+func (u *Uploader) Wait(ctx context.Context) error {
+	done, idle := u.doneChan()
+	if idle {
+		return u.err()
+	}
+
+	select {
+	case <-done:
+		return u.err()
+	case <-ctx.Done():
+		return errors.Join(ctx.Err(), u.err())
+	}
+}
+
+func (u *Uploader) ReplaceSpanAttachmentAttrs(attrs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
+	var rewritten []attribute.KeyValue
+	changed := false
+
+	for i, attr := range attrs {
+		key := string(attr.Key)
+		if !strings.HasPrefix(key, attachmentDataAttrPrefix) {
+			if rewritten != nil {
+				rewritten = append(rewritten, attr)
+			}
+			continue
+		}
+		if attr.Value.Type() != attribute.STRING {
+			continue
+		}
+		ref, data, ok := attachmentFromJSON(attr.Value.AsString())
+		if !ok {
+			continue
+		}
+		if rewritten == nil {
+			rewritten = make([]attribute.KeyValue, 0, len(attrs))
+			rewritten = append(rewritten, attrs[:i]...)
+		}
+		publicKey := strings.TrimPrefix(key, attachmentDataAttrPrefix)
+		refJSON, err := json.Marshal(ref)
+		if err != nil {
+			continue
+		}
+		rewritten = setOrAppendAttr(rewritten, attribute.String(publicKey, string(refJSON)))
+		u.uploadAsync(ref, data)
+		changed = true
+	}
+	if !changed {
+		return attrs, false
+	}
+	return rewritten, true
+}
+
+func setOrAppendAttr(attrs []attribute.KeyValue, attr attribute.KeyValue) []attribute.KeyValue {
+	for i := range attrs {
+		if attrs[i].Key == attr.Key {
+			attrs[i] = attr
+			return attrs
+		}
+	}
+	return append(attrs, attr)
+}
+
+func attachmentFromJSON(jsonStr string) (Reference, []byte, bool) {
+	var m map[string]any
+	if err := json.Unmarshal([]byte(jsonStr), &m); err != nil {
+		return Reference{}, nil, false
+	}
+	return attachmentFromMap(m)
+}
+
+func attachmentFromMap(m map[string]any) (Reference, []byte, bool) {
+	if typ, _ := m["type"].(string); typ != base64AttachmentType {
+		return Reference{}, nil, false
+	}
+	content, _ := m["content"].(string)
+	ct, data, ok := parseDataURL(content)
+	if !ok {
+		return Reference{}, nil, false
+	}
+	return newReference("attachment", ct), data, true
+}
+
+func newReference(filename, contentType string) Reference {
+	return Reference{
+		Type:        "braintrust_attachment",
+		Filename:    filename,
+		ContentType: contentType,
+		Key:         uuid.NewString(),
+	}
+}
+
+func parseDataURL(s string) (string, []byte, bool) {
+	if !strings.HasPrefix(s, "data:") {
+		return "", nil, false
+	}
+	comma := strings.IndexByte(s, ',')
+	if comma < 0 {
+		return "", nil, false
+	}
+	meta, payload := s[5:comma], s[comma+1:]
+	parts := strings.Split(meta, ";")
+	if len(parts) < 2 || parts[len(parts)-1] != "base64" {
+		return "", nil, false
+	}
+	ct := parts[0]
+	if ct == "" {
+		ct = "application/octet-stream"
+	}
+	if mt, _, err := mime.ParseMediaType(ct); err == nil {
+		ct = mt
+	}
+	data, err := base64.StdEncoding.DecodeString(payload)
+	if err != nil {
+		return "", nil, false
+	}
+	return ct, data, true
+}
+
+func (u *Uploader) uploadAsync(ref Reference, data []byte) {
+	u.startUpload()
+
+	// Backpressure: block span export when the bounded upload queue is full,
+	// matching Sentry's transport pattern of a fixed queue plus workers while
+	// preserving Braintrust's requirement that attachment references are not
+	// silently dropped.
+	u.queue <- uploadTask{ref: ref, data: data}
+}
+
+func (u *Uploader) worker() {
+	for task := range u.queue {
+		if err := u.upload(context.Background(), task.ref, task.data); err != nil {
+			err = fmt.Errorf("upload attachment %s: %w", task.ref.Key, err)
+			u.addErr(err)
+			u.logger.Warn("failed to upload attachment", "error", err, "key", task.ref.Key)
+		}
+		u.finishUpload()
+	}
+}
+
+func (u *Uploader) startUpload() {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	if u.inFlight == 0 {
+		u.done = make(chan struct{})
+	}
+	u.inFlight++
+}
+
+func (u *Uploader) finishUpload() {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.inFlight--
+	if u.inFlight == 0 {
+		close(u.done)
+	}
+}
+
+func (u *Uploader) doneChan() (<-chan struct{}, bool) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.done, u.inFlight == 0
+}
+
+func (u *Uploader) addErr(err error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.errs = append(u.errs, err)
+}
+
+func (u *Uploader) err() error {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return errors.Join(u.errs...)
+}
+
+func (u *Uploader) upload(ctx context.Context, ref Reference, data []byte) error {
+	if err := u.session.Login(ctx); err != nil {
+		return fmt.Errorf("login before attachment upload: %w", err)
+	}
+	api := u.session.APIInfo()
+	org := u.session.OrgInfo()
+	body := map[string]string{"key": ref.Key, "filename": ref.Filename, "content_type": ref.ContentType, "org_id": org.ID}
+	b, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal attachment request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(api.APIURL, "/")+"/attachment", bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+api.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := u.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("signed URL request failed: %s", resp.Status)
+	}
+	var meta struct {
+		SignedURL string            `json:"signedUrl"`
+		Headers   map[string]string `json:"headers"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&meta); err != nil {
+		return err
+	}
+	if meta.SignedURL == "" {
+		return fmt.Errorf("missing signedUrl")
+	}
+	req, err = http.NewRequestWithContext(ctx, http.MethodPut, meta.SignedURL, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	for k, v := range meta.Headers {
+		req.Header.Set(k, v)
+	}
+	resp, err = u.client.Do(req)
+	if err != nil {
+		return err
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("object upload failed: %s", resp.Status)
+	}
+	return nil
+}

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -26,6 +26,7 @@ package trace
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -37,7 +38,10 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
 	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/braintrustdata/braintrust-sdk-go/trace/attachment"
 
 	"github.com/braintrustdata/braintrust-sdk-go/internal/auth"
 	"github.com/braintrustdata/braintrust-sdk-go/logger"
@@ -349,6 +353,7 @@ type spanProcessor struct {
 	otelAttrs   *otelAttrs
 	session     *auth.Session // Session provides endpoints and org name
 	logger      logger.Logger
+	uploader    *attachment.Uploader
 }
 
 // newSpanProcessor creates a new span processor that wraps another processor and adds parent labeling.
@@ -366,6 +371,8 @@ func newSpanProcessor(
 	// Initialize with empty org name - will be looked up dynamically from session
 	attrs := newOtelAttrs(defaultParent, "", appURL)
 
+	uploader := attachment.NewUploader(session, log)
+
 	sp := &spanProcessor{
 		wrapped:     proc,
 		filters:     filters,
@@ -373,6 +380,7 @@ func newSpanProcessor(
 		otelAttrs:   attrs,
 		session:     session,
 		logger:      log,
+		uploader:    uploader,
 	}
 
 	return sp, nil
@@ -420,9 +428,24 @@ func (sp *spanProcessor) OnStart(ctx context.Context, span sdktrace.ReadWriteSpa
 func (sp *spanProcessor) OnEnd(span sdktrace.ReadOnlySpan) {
 	// Apply filters to determine if we should forward this span
 	if sp.shouldForwardSpan(span) {
-		sp.wrapped.OnEnd(span)
+		sp.wrapped.OnEnd(sp.processAttachments(span))
 	}
 }
+
+func (sp *spanProcessor) processAttachments(span sdktrace.ReadOnlySpan) sdktrace.ReadOnlySpan {
+	attrs, changed := sp.uploader.ReplaceSpanAttachmentAttrs(span.Attributes())
+	if !changed {
+		return span
+	}
+	return &attachmentSpan{ReadOnlySpan: span, attrs: attrs}
+}
+
+type attachmentSpan struct {
+	sdktrace.ReadOnlySpan
+	attrs []attribute.KeyValue
+}
+
+func (s *attachmentSpan) Attributes() []attribute.KeyValue { return s.attrs }
 
 // shouldForwardSpan applies filter functions to determine if a span should be forwarded.
 // Only rootFilters are applied to root spans. Filter functions are applied in
@@ -454,12 +477,16 @@ func (sp *spanProcessor) shouldForwardSpan(span sdktrace.ReadOnlySpan) bool {
 
 // Shutdown shuts down the span processor.
 func (sp *spanProcessor) Shutdown(ctx context.Context) error {
-	return sp.wrapped.Shutdown(ctx)
+	uploadErr := sp.uploader.Shutdown(ctx)
+	shutdownErr := sp.wrapped.Shutdown(ctx)
+	return errors.Join(uploadErr, shutdownErr)
 }
 
 // ForceFlush forces a flush of the span processor.
 func (sp *spanProcessor) ForceFlush(ctx context.Context) error {
-	return sp.wrapped.ForceFlush(ctx)
+	waitErr := sp.uploader.Wait(ctx)
+	flushErr := sp.wrapped.ForceFlush(ctx)
+	return errors.Join(waitErr, flushErr)
 }
 
 var _ sdktrace.SpanProcessor = &spanProcessor{}

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -2,6 +2,9 @@ package trace
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,6 +16,7 @@ import (
 
 	"github.com/braintrustdata/braintrust-sdk-go/internal/auth"
 	"github.com/braintrustdata/braintrust-sdk-go/logger"
+	btattachment "github.com/braintrustdata/braintrust-sdk-go/trace/attachment"
 )
 
 // Test helper: create a session for testing with proper auth info
@@ -26,6 +30,62 @@ func newTestSession() *auth.Session {
 		"https://www.braintrust.dev",
 		logger.Discard(),
 	)
+}
+
+func TestSpanProcessor_SetAttachmentOnSpanExportsReference(t *testing.T) {
+	var uploaded string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/attachment":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"signedUrl":"`+serverURL(r)+`/upload","headers":{"Content-Type":"text/plain"}}`)
+		case "/upload":
+			body, _ := io.ReadAll(r.Body)
+			uploaded = string(body)
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	session := auth.NewTestSession("test-api-key", "test-org-id", "test-org", server.URL, server.URL, server.URL, logger.Discard())
+	exporter := tracetest.NewInMemoryExporter()
+	processor, err := newSpanProcessor(sdktrace.NewSimpleSpanProcessor(exporter), getParent(Config{}), nil, nil, session, logger.Discard())
+	assert.NoError(t, err)
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(processor))
+
+	_, span := tp.Tracer("test").Start(context.Background(), "span")
+	requireNoError(t, btattachment.SetAttachmentOnSpan(span, "custom.image", btattachment.FromBytes(btattachment.TextPlain, []byte("hello"))))
+	span.End()
+	requireNoError(t, tp.ForceFlush(context.Background()))
+
+	spans := exporter.GetSpans()
+	assert.Len(t, spans, 1)
+	assert.Empty(t, findAttr(spans[0].Attributes, "braintrust.attachment.data.custom.image"))
+	attr := findAttr(spans[0].Attributes, "custom.image")
+	assert.NotContains(t, attr, "aGVsbG8=")
+	assert.Contains(t, attr, "braintrust_attachment")
+	assert.Contains(t, attr, "text/plain")
+	assert.Equal(t, "hello", uploaded)
+}
+
+func serverURL(r *http.Request) string { return "http://" + r.Host }
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func findAttr(attrs []attribute.KeyValue, key string) string {
+	for _, attr := range attrs {
+		if string(attr.Key) == key {
+			return attr.Value.AsString()
+		}
+	}
+	return ""
 }
 
 func TestSpanFilterFunc_WithAttributes(t *testing.T) {


### PR DESCRIPTION
- add attachment.SetAttachmentOnSpan for top-level span attachments
- rewrite private attachment data attrs into Braintrust attachment references during span export
- remove JSON string attachment scanning fallback
- update attachment examples and tests