### PR TITLE
ci: gate release behind environment and streamline pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,19 +7,33 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.26.x
-      - name: Use local Braintrust modules
-        run: ./scripts/apply_local_braintrust_replaces.sh
+          go-version-file: go.work
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.11.4
+
+  # mod-verify is OS / Go-version independent (just runs `go mod tidy`
+  # and asserts the working tree is clean), so it lives in its own job
+  # instead of running across the full test matrix.
+  mod-verify:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.work
+      - name: Verify modules
+        run: make mod-verify
+        env:
+          GOTOOLCHAIN: local
 
   test:
     strategy:
@@ -28,12 +42,10 @@ jobs:
         go-version: [1.25.x, 1.26.x]
         # FIXME[matt] add windows testing, we need to fix some timing
         # tests.
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-24.04, macos-latest]
     env:
+      # Disable cgo so test binaries match the static builds we ship.
       CGO_ENABLED: 0
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY}}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY}}
-      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY}}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -45,10 +57,6 @@ jobs:
         env:
           GOTOOLCHAIN: local
         run: go install github.com/DataDog/orchestrion@v1.6.1
-      - name: Verify modules
-        run: make mod-verify
-        env:
-          GOTOOLCHAIN: local
       - name: Use local Braintrust modules for test and build
         run: ./scripts/apply_local_braintrust_replaces.sh
       - name: Test
@@ -60,10 +68,26 @@ jobs:
         env:
           GOTOOLCHAIN: local
 
+  # Compile-check every example module so SDK API regressions surface in
+  # CI instead of when a user copies the example. `make build-examples`
+  # internally applies local replace directives to example go.mod files.
+  build-examples:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.work
+      - name: Build examples
+        run: make build-examples
+        env:
+          GOTOOLCHAIN: local
+
   ci-passed:
     name: ci-passed
-    needs: [lint, test]
-    runs-on: ubuntu-latest
+    needs: [lint, mod-verify, test, build-examples]
+    runs-on: ubuntu-24.04
     steps:
       - name: Mark CI as passed
         run: echo "All CI jobs passed successfully"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,11 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-24.04
+    # Gate the release behind a protected GitHub Environment.
+    # Required reviewers, deployment branch/tag rules, and any release
+    # secrets are configured on the environment itself in repo settings
+    # (Settings → Environments → release).
+    environment: release
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -27,37 +32,19 @@ jobs:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
 
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.work
-
-      - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
-        with:
-          version: v2.11.4
-
-      - name: Install orchestrion
-        env:
-          GOTOOLCHAIN: local
-        run: go install github.com/DataDog/orchestrion@v1.6.1
-
       - name: Install goreleaser
-        run: |
-          cd /tmp
-          wget -q https://github.com/goreleaser/goreleaser/releases/download/v2.12.7/goreleaser_Linux_x86_64.tar.gz
-          tar -xzf goreleaser_Linux_x86_64.tar.gz goreleaser
-          sudo mv goreleaser /usr/local/bin/
-          goreleaser --version
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
+        with:
+          install-only: true
+          version: v2.12.7
 
       - name: Publish release
-        run: make release
+        # We call publish.sh directly instead of `make release` to skip the
+        # `ci` prereq. Safety nets:
+        #   - push: tags  → tag-release.yml just ran `make ci` on this commit.
+        #   - workflow_dispatch → the `release` environment requires reviewer
+        #     approval, so a human confirms the tag is safe to re-publish.
+        run: ./scripts/publish.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
-          # these envars are needed because `make release` runs CI as a final sanity check
-          CGO_ENABLED: 0
-          GOTOOLCHAIN: local
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -56,9 +56,6 @@ jobs:
         env:
           CGO_ENABLED: 0
           GOTOOLCHAIN: local
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
 
       - name: Configure git identity
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help ci build clean test test-quiet test-vcr-off test-vcr-record test-vcr-verify cover cover-path lint fmt mod-verify fix godoc examples release generate check-nested-modules local-braintrust-replaces
+.PHONY: help ci build build-examples clean test test-quiet test-vcr-off test-vcr-record test-vcr-verify cover cover-path lint fmt mod-verify fix godoc examples release generate check-nested-modules local-braintrust-replaces
 
 # Releasable nested modules, read from the manifest at make-time.
 NESTED_MODULE_DIRS := $(shell ./scripts/list_nested_modules.sh)
@@ -7,6 +7,7 @@ help:
 	@echo "Available commands:"
 	@echo "  help             - Show this help message"
 	@echo "  build            - Build all packages"
+	@echo "  build-examples   - Compile-check every example module"
 	@echo "  test             - Run all tests (VCR replay mode, fast)"
 	@echo "  test-quiet       - Run all tests (quiet - no 'ok' lines)"
 	@echo "  test-vcr-off     - Run all tests without VCR (requires API keys)"
@@ -33,6 +34,24 @@ local-braintrust-replaces:
 build:
 	go build ./...
 	for dir in $(NESTED_MODULE_DIRS); do go build -C $$dir ./...; done
+
+# Compile-check every example module. Used by CI to catch SDK API
+# regressions that would silently rot examples. We use `go vet` instead
+# of `go build` because vet compiles + typechecks without emitting
+# binaries (and `go build ./...` writes per-package binaries even with
+# -o /dev/null when multiple main packages are present). `make examples`
+# would also catch this but requires API keys to execute.
+#
+# This mutates example go.mod files with local replace directives, so
+# don't chain this into `make ci` / `make release` (publish.sh requires
+# a clean tree).
+build-examples:
+	./scripts/apply_local_braintrust_replaces.sh --include-examples
+	@find examples -name go.mod -print | while IFS= read -r gomod; do \
+		dir=$$(dirname "$$gomod"); \
+		echo "Checking $$dir..."; \
+		GOWORK=off go vet -C "$$dir" ./... || exit 1; \
+	done
 
 clean:
 	go clean
@@ -104,6 +123,10 @@ examples:
 
 precommit: fmt ci
 
+# Publish a tagged release. Runs CI first so local / ad-hoc invocations
+# are always lint+test+build gated. The release workflow skips this by
+# calling ./scripts/publish.sh directly (CI is already covered upstream
+# by tag-release.yml or by the environment reviewer gate on manual dispatch).
 release: ci
 	./scripts/publish.sh
 

--- a/scripts/apply_local_braintrust_replaces.sh
+++ b/scripts/apply_local_braintrust_replaces.sh
@@ -6,10 +6,31 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd -- "$SCRIPT_DIR/.." && pwd)
 ROOT_MODULE="github.com/braintrustdata/braintrust-sdk-go"
 
+# Default: only patch the SDK root + releasable nested modules. Pass
+# --include-examples to also patch out-of-workspace example modules
+# (used by `make build-examples` to verify examples build against
+# current SDK source). We keep this off by default because
+# scripts/publish.sh requires a clean working tree, and mutating
+# example go.mod files would break the release path.
+INCLUDE_EXAMPLES=false
+if [[ "${1:-}" == "--include-examples" ]]; then
+    INCLUDE_EXAMPLES=true
+fi
+
 MODULE_DIRS=(".")
 while IFS= read -r module; do
     MODULE_DIRS+=("$module")
 done < <("$SCRIPT_DIR/list_nested_modules.sh")
+
+if [[ "$INCLUDE_EXAMPLES" == "true" ]]; then
+    while IFS= read -r gomod; do
+        abs_dir=$(dirname "$gomod")
+        rel_dir=${abs_dir#"$REPO_ROOT/"}
+        # Skip the in-workspace examples module (resolved via go.work).
+        [[ "$rel_dir" == "examples" ]] && continue
+        MODULE_DIRS+=("$rel_dir")
+    done < <(find "$REPO_ROOT/examples" -name go.mod -print | sort)
+fi
 
 has_replace() {
     local module="$1"


### PR DESCRIPTION
resolves https://linear.app/braintrustdata/issue/BT-5171/set-up-publish-workflow-environment-rules-for-go-sdk

Mirror the release gating in braintrust-sdk-java and braintrust-sdk-javascript by running the publish job in a protected `release` GitHub Environment, then trim duplicate work and tighten the surrounding workflows.

Release gating and pipeline cleanup:
- Add `environment: release` to release.yml so reviewer approval / branch rules configured in repo settings gate every publish.
- Stop re-running `make ci` from the release workflow. tag-release.yml already runs CI on the same commit before pushing the tag, and the environment reviewer is the safety net on workflow_dispatch re-publishes. publish.sh is invoked directly to keep `make release` (which still depends on `ci`) safe for local use.
- Drop unused OPENAI/ANTHROPIC/BRAINTRUST API key env vars from ci.yml, release.yml, and tag-release.yml. All tests run under VCR_MODE=replay in CI and fall back to dummy values; the keys were dead weight.

CI workflow improvements:
- Split `mod-verify` into a dedicated job. The check is OS/Go-version independent so running it once is enough; previously it ran 4× across the test matrix.
- Add a `build-examples` job that compile-checks every example module with `go vet`. Catches SDK API regressions that would silently rot examples without requiring API keys to actually run them.
- Normalize all runners to `ubuntu-24.04` (was a mix of `ubuntu-latest` and `ubuntu-24.04`).
- Drive lint job's Go version from `go.work` instead of a hardcoded `1.26.x`.
- Drop the `apply_local_braintrust_replaces.sh` step from the lint job — root module linting doesn't need cross-module replaces.
- Replace the manual goreleaser wget+tar+sudo install with the official `goreleaser/goreleaser-action`, SHA-pinned to v7.2.2 with `install-only` so publish.sh still drives the publish.

Supporting changes:
- Add `make build-examples` target and an `--include-examples` flag on `apply_local_braintrust_replaces.sh`. The flag is opt-in because mutating example go.mod files would break publish.sh's clean-tree check.