### PR TITLE
Add span origin provenance

### DIFF
--- a/client.go
+++ b/client.go
@@ -127,6 +127,12 @@ func (c *Client) setupTracing() error {
 		Exporter:                 c.config.Exporter,
 		Logger:                   c.logger,
 	}
+	if c.config.Environment != nil {
+		traceConfig.Environment = &bttrace.SpanOriginEnvironment{
+			Type: c.config.Environment.Type,
+			Name: c.config.Environment.Name,
+		}
+	}
 
 	// Add Braintrust span processor to the provided TracerProvider
 	c.logger.Debug("enabling braintrust tracing on provider")

--- a/config/config.go
+++ b/config/config.go
@@ -114,18 +114,38 @@ func DetectEnvironment(explicit *Environment) *Environment {
 	if getProcessEnvString("CI") != "" {
 		return &Environment{Type: "ci", Name: "ci"}
 	}
-	for key, name := range map[string]string{
-		"VERCEL": "vercel", "NETLIFY": "netlify", "AWS_LAMBDA_FUNCTION_NAME": "aws_lambda",
-		"AWS_EXECUTION_ENV": "aws_lambda", "K_SERVICE": "cloud_run", "FUNCTION_TARGET": "gcp_functions",
-		"KUBERNETES_SERVICE_HOST": "kubernetes", "ECS_CONTAINER_METADATA_URI": "ecs",
-		"ECS_CONTAINER_METADATA_URI_V4": "ecs", "DYNO": "heroku", "FLY_APP_NAME": "fly",
-		"RAILWAY_ENVIRONMENT": "railway", "RENDER_SERVICE_NAME": "render",
-	} {
-		if getProcessEnvString(key) != "" {
-			return &Environment{Type: "server", Name: name}
-		}
+	if name := detectServerEnvironmentName(); name != "" {
+		return &Environment{Type: "server", Name: name}
 	}
 	return nil
+}
+
+func detectServerEnvironmentName() string {
+	for key, name := range map[string]string{"VERCEL": "vercel", "NETLIFY": "netlify"} {
+		if getProcessEnvString(key) != "" {
+			return name
+		}
+	}
+	if getProcessEnvString("ECS_CONTAINER_METADATA_URI") != "" || getProcessEnvString("ECS_CONTAINER_METADATA_URI_V4") != "" {
+		return "ecs"
+	}
+	if value := getProcessEnvString("AWS_EXECUTION_ENV"); strings.HasPrefix(value, "AWS_ECS_") {
+		return "ecs"
+	} else if strings.HasPrefix(value, "AWS_Lambda_") {
+		return "aws_lambda"
+	}
+	if getProcessEnvString("AWS_LAMBDA_FUNCTION_NAME") != "" {
+		return "aws_lambda"
+	}
+	for key, name := range map[string]string{
+		"K_SERVICE": "cloud_run", "FUNCTION_TARGET": "gcp_functions", "KUBERNETES_SERVICE_HOST": "kubernetes",
+		"DYNO": "heroku", "FLY_APP_NAME": "fly", "RAILWAY_ENVIRONMENT": "railway", "RENDER_SERVICE_NAME": "render",
+	} {
+		if getProcessEnvString(key) != "" {
+			return name
+		}
+	}
+	return ""
 }
 
 func getProcessEnvString(key string) string {

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	Logger logger.Logger
 }
 
+// Environment describes where spans are produced for span-origin provenance.
 type Environment struct {
 	Type string
 	Name string
@@ -91,6 +92,8 @@ func FromEnv() *Config {
 	return cfg
 }
 
+// DetectEnvironment resolves span-origin environment provenance from an
+// explicit value, Braintrust environment variables, CI, and server runtimes.
 func DetectEnvironment(explicit *Environment) *Environment {
 	if explicit != nil {
 		return explicit

--- a/config/config.go
+++ b/config/config.go
@@ -98,8 +98,10 @@ func DetectEnvironment(explicit *Environment) *Environment {
 	if explicit != nil {
 		return explicit
 	}
-	if envType := getEnvString("BRAINTRUST_ENVIRONMENT_TYPE", ""); envType != "" {
-		return &Environment{Type: envType, Name: getEnvString("BRAINTRUST_ENVIRONMENT_NAME", "")}
+	envType := getEnvString("BRAINTRUST_ENVIRONMENT_TYPE", "")
+	envName := getEnvString("BRAINTRUST_ENVIRONMENT_NAME", "")
+	if envType != "" || envName != "" {
+		return &Environment{Type: envType, Name: envName}
 	}
 	for key, name := range map[string]string{
 		"GITHUB_ACTIONS": "github_actions", "GITLAB_CI": "gitlab_ci", "CIRCLECI": "circleci",

--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"go.opentelemetry.io/otel/sdk/trace"
@@ -37,9 +38,15 @@ type Config struct {
 	AutoConvertAIAttachments bool // scan spans for base64 attachments and upload them (default: true)
 	SpanFilterFuncs          []SpanFilterFunc
 	Exporter                 trace.SpanExporter
+	Environment              *Environment
 
 	// Logger
 	Logger logger.Logger
+}
+
+type Environment struct {
+	Type string
+	Name string
 }
 
 // SpanFilterFunc is a function that decides which spans to send to Braintrust.
@@ -76,6 +83,7 @@ func FromEnv() *Config {
 		EnableTraceConsoleLog:    getEnvBool("BRAINTRUST_ENABLE_TRACE_CONSOLE_LOG", false),
 		EnableBuiltinAdkTraces:   getEnvBool("BRAINTRUST_OTEL_ENABLE_BUILTIN_ADK_TRACES", false),
 		AutoConvertAIAttachments: getEnvBool("BRAINTRUST_AUTO_CONVERT_AI_ATTACHMENTS", true),
+		Environment:              DetectEnvironment(nil),
 	}
 	if cfg.APIKey == "" {
 		cfg.APIKeyResolver = apikey.NewResolver()
@@ -83,12 +91,83 @@ func FromEnv() *Config {
 	return cfg
 }
 
+func DetectEnvironment(explicit *Environment) *Environment {
+	if explicit != nil {
+		return explicit
+	}
+	if envType := getEnvString("BRAINTRUST_ENVIRONMENT_TYPE", ""); envType != "" {
+		return &Environment{Type: envType, Name: getEnvString("BRAINTRUST_ENVIRONMENT_NAME", "")}
+	}
+	for key, name := range map[string]string{
+		"GITHUB_ACTIONS": "github_actions", "GITLAB_CI": "gitlab_ci", "CIRCLECI": "circleci",
+		"BUILDKITE": "buildkite", "JENKINS_URL": "jenkins", "JENKINS_HOME": "jenkins",
+		"TF_BUILD": "azure_pipelines", "TEAMCITY_VERSION": "teamcity", "TRAVIS": "travis",
+		"BITBUCKET_BUILD_NUMBER": "bitbucket",
+	} {
+		if getProcessEnvString(key) != "" {
+			return &Environment{Type: "ci", Name: name}
+		}
+	}
+	if getProcessEnvString("CI") != "" {
+		return &Environment{Type: "ci", Name: "ci"}
+	}
+	for key, name := range map[string]string{
+		"VERCEL": "vercel", "NETLIFY": "netlify", "AWS_LAMBDA_FUNCTION_NAME": "aws_lambda",
+		"AWS_EXECUTION_ENV": "aws_lambda", "K_SERVICE": "cloud_run", "FUNCTION_TARGET": "gcp_functions",
+		"KUBERNETES_SERVICE_HOST": "kubernetes", "ECS_CONTAINER_METADATA_URI": "ecs",
+		"ECS_CONTAINER_METADATA_URI_V4": "ecs", "DYNO": "heroku", "FLY_APP_NAME": "fly",
+		"RAILWAY_ENVIRONMENT": "railway", "RENDER_SERVICE_NAME": "render",
+	} {
+		if getProcessEnvString(key) != "" {
+			return &Environment{Type: "server", Name: name}
+		}
+	}
+	return nil
+}
+
+func getProcessEnvString(key string) string {
+	return strings.TrimSpace(os.Getenv(key))
+}
+
 // getEnvString returns the trimmed environment variable value or the default
 func getEnvString(key, defaultValue string) string {
-	if value := os.Getenv(key); value != "" {
-		return strings.TrimSpace(value)
+	if value := getProcessEnvString(key); value != "" {
+		return value
+	}
+	if value := getBraintrustEnvFileValue(key); value != "" {
+		return value
 	}
 	return defaultValue
+}
+
+func getBraintrustEnvFileValue(key string) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	for depth := 0; depth <= 64; depth++ {
+		envPath := filepath.Join(dir, ".env.braintrust")
+		if data, err := os.ReadFile(envPath); err == nil {
+			for _, line := range strings.Split(string(data), "\n") {
+				line = strings.TrimSpace(line)
+				if line == "" || strings.HasPrefix(line, "#") {
+					continue
+				}
+				name, value, ok := strings.Cut(line, "=")
+				if !ok || strings.TrimSpace(name) != key {
+					continue
+				}
+				return strings.Trim(strings.TrimSpace(value), `"'`)
+			}
+			return ""
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return ""
 }
 
 // getEnvBool returns the environment variable as a bool or the default

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -94,6 +94,36 @@ func TestFromEnv_BooleanParsing(t *testing.T) {
 	}
 }
 
+func TestDetectEnvironment_AWSExecutionEnvClassifiesECSBeforeLambda(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("GITLAB_CI", "")
+	t.Setenv("CIRCLECI", "")
+	t.Setenv("BUILDKITE", "")
+	t.Setenv("CI", "")
+	t.Setenv("AWS_EXECUTION_ENV", "AWS_ECS_FARGATE")
+
+	env := DetectEnvironment(nil)
+
+	assert.NotNil(t, env)
+	assert.Equal(t, "server", env.Type)
+	assert.Equal(t, "ecs", env.Name)
+}
+
+func TestDetectEnvironment_AWSExecutionEnvClassifiesLambdaWhenLambdaSpecific(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("GITLAB_CI", "")
+	t.Setenv("CIRCLECI", "")
+	t.Setenv("BUILDKITE", "")
+	t.Setenv("CI", "")
+	t.Setenv("AWS_EXECUTION_ENV", "AWS_Lambda_go1.x")
+
+	env := DetectEnvironment(nil)
+
+	assert.NotNil(t, env)
+	assert.Equal(t, "server", env.Type)
+	assert.Equal(t, "aws_lambda", env.Name)
+}
+
 func TestConfig_IsValid(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -109,6 +109,22 @@ func TestDetectEnvironment_AWSExecutionEnvClassifiesECSBeforeLambda(t *testing.T
 	assert.Equal(t, "ecs", env.Name)
 }
 
+func TestDetectEnvironment_ExplicitNameWithoutType(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("GITLAB_CI", "")
+	t.Setenv("CIRCLECI", "")
+	t.Setenv("BUILDKITE", "")
+	t.Setenv("CI", "")
+	t.Setenv("BRAINTRUST_ENVIRONMENT_TYPE", "")
+	t.Setenv("BRAINTRUST_ENVIRONMENT_NAME", "staging")
+
+	env := DetectEnvironment(nil)
+
+	assert.NotNil(t, env)
+	assert.Empty(t, env.Type)
+	assert.Equal(t, "staging", env.Name)
+}
+
 func TestDetectEnvironment_AWSExecutionEnvClassifiesLambdaWhenLambdaSpecific(t *testing.T) {
 	t.Setenv("GITHUB_ACTIONS", "")
 	t.Setenv("GITLAB_CI", "")

--- a/options.go
+++ b/options.go
@@ -61,6 +61,16 @@ func WithProjectID(projectID string) Option {
 	}
 }
 
+// WithEnvironment sets span-origin environment provenance.
+func WithEnvironment(environmentType string, name ...string) Option {
+	return func(c *config.Config) {
+		c.Environment = &config.Environment{Type: environmentType}
+		if len(name) > 0 {
+			c.Environment.Name = name[0]
+		}
+	}
+}
+
 // WithLogger sets a custom logger for the SDK
 // If not provided, a default logger will be used
 func WithLogger(l logger.Logger) Option {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -555,13 +555,12 @@ func (sp *spanProcessor) OnStart(ctx context.Context, span sdktrace.ReadWriteSpa
 
 	// Set any other additional attributes (org name, app URL, etc.)
 	span.SetAttributes(attrs...)
-	span.SetAttributes(spanOriginAttrs(sp.environment)...)
 
 	// Delegate to wrapped processor
 	sp.wrapped.OnStart(ctx, span)
 }
 
-func spanOriginAttrs(environment *SpanOriginEnvironment) []attribute.KeyValue {
+func spanOriginContextJSON(span sdktrace.ReadOnlySpan, environment *SpanOriginEnvironment) string {
 	origin := map[string]any{
 		"span_origin": map[string]any{
 			"name":            "braintrust.sdk.go",
@@ -569,29 +568,47 @@ func spanOriginAttrs(environment *SpanOriginEnvironment) []attribute.KeyValue {
 			"instrumentation": map[string]any{"name": "braintrust-go"},
 		},
 	}
-	if environment != nil {
-		env := map[string]any{"type": environment.Type}
-		if environment.Name != "" {
-			env["name"] = environment.Name
+	for _, attr := range span.Attributes() {
+		if attr.Key != contextJSONAttrKey {
+			continue
 		}
+		var existing map[string]any
+		if err := json.Unmarshal([]byte(attr.Value.AsString()), &existing); err == nil {
+			for key, value := range existing {
+				if key == "span_origin" {
+					continue
+				}
+				origin[key] = value
+			}
+			if existingOrigin, ok := existing["span_origin"].(map[string]any); ok {
+				spanOrigin, ok := origin["span_origin"].(map[string]any)
+				if ok {
+					for key, value := range existingOrigin {
+						spanOrigin[key] = value
+					}
+				}
+			}
+		}
+		break
+	}
+	if environment != nil {
 		spanOrigin, ok := origin["span_origin"].(map[string]any)
 		if !ok {
-			return nil
+			return "{}"
 		}
-		spanOrigin["environment"] = env
+		if _, exists := spanOrigin["environment"]; !exists {
+			env := map[string]any{"type": environment.Type}
+			if environment.Name != "" {
+				env["name"] = environment.Name
+			}
+			spanOrigin["environment"] = env
+		}
 	}
 	data, err := json.Marshal(origin)
 	if err != nil {
-		return nil
+		return "{}"
 	}
-	attrs := []attribute.KeyValue{attribute.String(contextJSONAttrKey, string(data))}
-	if environment != nil {
-		attrs = append(attrs, attribute.String(environmentTypeAttrKey, environment.Type))
-		if environment.Name != "" {
-			attrs = append(attrs, attribute.String(environmentNameAttrKey, environment.Name))
-		}
-	}
-	return attrs
+	return string(data)
 }
 
 func sdkVersion() string {
@@ -632,18 +649,39 @@ func resolveEnvironment(explicit *SpanOriginEnvironment) *SpanOriginEnvironment 
 	if os.Getenv("CI") != "" {
 		return &SpanOriginEnvironment{Type: "ci", Name: "ci"}
 	}
-	for key, name := range map[string]string{
-		"VERCEL": "vercel", "NETLIFY": "netlify", "AWS_LAMBDA_FUNCTION_NAME": "aws_lambda",
-		"AWS_EXECUTION_ENV": "aws_lambda", "K_SERVICE": "cloud_run", "FUNCTION_TARGET": "gcp_functions",
-		"KUBERNETES_SERVICE_HOST": "kubernetes", "ECS_CONTAINER_METADATA_URI": "ecs",
-		"ECS_CONTAINER_METADATA_URI_V4": "ecs", "DYNO": "heroku", "FLY_APP_NAME": "fly",
-		"RAILWAY_ENVIRONMENT": "railway", "RENDER_SERVICE_NAME": "render",
-	} {
-		if strings.TrimSpace(os.Getenv(key)) != "" {
-			return &SpanOriginEnvironment{Type: "server", Name: name}
-		}
+	if name := detectServerEnvironmentName(); name != "" {
+		return &SpanOriginEnvironment{Type: "server", Name: name}
 	}
 	return nil
+}
+
+func detectServerEnvironmentName() string {
+	for key, name := range map[string]string{"VERCEL": "vercel", "NETLIFY": "netlify"} {
+		if strings.TrimSpace(os.Getenv(key)) != "" {
+			return name
+		}
+	}
+	if strings.TrimSpace(os.Getenv("ECS_CONTAINER_METADATA_URI")) != "" ||
+		strings.TrimSpace(os.Getenv("ECS_CONTAINER_METADATA_URI_V4")) != "" {
+		return "ecs"
+	}
+	if value := strings.TrimSpace(os.Getenv("AWS_EXECUTION_ENV")); strings.HasPrefix(value, "AWS_ECS_") {
+		return "ecs"
+	} else if strings.HasPrefix(value, "AWS_Lambda_") {
+		return "aws_lambda"
+	}
+	if strings.TrimSpace(os.Getenv("AWS_LAMBDA_FUNCTION_NAME")) != "" {
+		return "aws_lambda"
+	}
+	for key, name := range map[string]string{
+		"K_SERVICE": "cloud_run", "FUNCTION_TARGET": "gcp_functions", "KUBERNETES_SERVICE_HOST": "kubernetes",
+		"DYNO": "heroku", "FLY_APP_NAME": "fly", "RAILWAY_ENVIRONMENT": "railway", "RENDER_SERVICE_NAME": "render",
+	} {
+		if strings.TrimSpace(os.Getenv(key)) != "" {
+			return name
+		}
+	}
+	return ""
 }
 
 func envValue(key string) string {
@@ -694,8 +732,21 @@ func (sp *spanProcessor) OnEnd(span sdktrace.ReadOnlySpan) {
 	if sp.attachmentProcessor != nil {
 		span = sp.processAttachments(span)
 	}
+	span = sp.addSpanOrigin(span)
 
 	sp.wrapped.OnEnd(span)
+}
+
+func (sp *spanProcessor) addSpanOrigin(span sdktrace.ReadOnlySpan) sdktrace.ReadOnlySpan {
+	overrides := make(map[attribute.Key]string)
+	overrides[contextJSONAttrKey] = spanOriginContextJSON(span, sp.environment)
+	if sp.environment != nil {
+		overrides[environmentTypeAttrKey] = sp.environment.Type
+		if sp.environment.Name != "" {
+			overrides[environmentNameAttrKey] = sp.environment.Name
+		}
+	}
+	return attachmentprocessor.NewTransformedSpan(span, overrides)
 }
 
 // processAttachments scans input_json and output_json for base64 attachments,

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -26,8 +26,12 @@ package trace
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
+	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -70,6 +74,13 @@ type Config struct {
 
 	// Logger
 	Logger logger.Logger
+
+	Environment *SpanOriginEnvironment
+}
+
+type SpanOriginEnvironment struct {
+	Type string
+	Name string
 }
 
 // SpanFilterFunc decides which spans to send to Braintrust.
@@ -161,6 +172,7 @@ func GetSpanProcessor(session *auth.Session, cfg Config) (sdktrace.SpanProcessor
 		log,
 		ap,
 		uploader,
+		resolveEnvironment(cfg.Environment),
 	)
 	if err != nil {
 		return nil, err
@@ -287,8 +299,11 @@ const ParentOtelAttrKey = "braintrust.parent"
 
 // Internal attribute keys for Braintrust span metadata.
 const (
-	orgAttrKey    = "braintrust.org"
-	appURLAttrKey = "braintrust.app_url"
+	orgAttrKey             = "braintrust.org"
+	appURLAttrKey          = "braintrust.app_url"
+	contextJSONAttrKey     = "braintrust.context_json"
+	environmentTypeAttrKey = "braintrust.environment.type"
+	environmentNameAttrKey = "braintrust.environment.name"
 )
 
 type contextKey string
@@ -470,6 +485,7 @@ type spanProcessor struct {
 	logger              logger.Logger
 	attachmentProcessor *attachmentprocessor.Processor // nil when attachment processing is disabled
 	attachmentUploader  attachmentprocessor.Uploader   // nil when attachment processing is disabled
+	environment         *SpanOriginEnvironment
 }
 
 // newSpanProcessor creates a new span processor that wraps another processor and adds parent labeling.
@@ -482,6 +498,7 @@ func newSpanProcessor(
 	log logger.Logger,
 	ap *attachmentprocessor.Processor,
 	uploader attachmentprocessor.Uploader,
+	environment *SpanOriginEnvironment,
 ) (*spanProcessor, error) {
 	// Get app URL from session
 	appURL := session.AppPublicURL()
@@ -498,6 +515,7 @@ func newSpanProcessor(
 		logger:              log,
 		attachmentProcessor: ap,
 		attachmentUploader:  uploader,
+		environment:         environment,
 	}
 
 	return sp, nil
@@ -536,9 +554,128 @@ func (sp *spanProcessor) OnStart(ctx context.Context, span sdktrace.ReadWriteSpa
 
 	// Set any other additional attributes (org name, app URL, etc.)
 	span.SetAttributes(attrs...)
+	span.SetAttributes(spanOriginAttrs(sp.environment)...)
 
 	// Delegate to wrapped processor
 	sp.wrapped.OnStart(ctx, span)
+}
+
+func spanOriginAttrs(environment *SpanOriginEnvironment) []attribute.KeyValue {
+	origin := map[string]any{
+		"span_origin": map[string]any{
+			"name":            "braintrust.sdk.go",
+			"version":         sdkVersion(),
+			"instrumentation": map[string]any{"name": "braintrust-go"},
+		},
+	}
+	if environment != nil {
+		env := map[string]any{"type": environment.Type}
+		if environment.Name != "" {
+			env["name"] = environment.Name
+		}
+		origin["span_origin"].(map[string]any)["environment"] = env
+	}
+	data, err := json.Marshal(origin)
+	if err != nil {
+		return nil
+	}
+	attrs := []attribute.KeyValue{attribute.String(contextJSONAttrKey, string(data))}
+	if environment != nil {
+		attrs = append(attrs, attribute.String(environmentTypeAttrKey, environment.Type))
+		if environment.Name != "" {
+			attrs = append(attrs, attribute.String(environmentNameAttrKey, environment.Name))
+		}
+	}
+	return attrs
+}
+
+func sdkVersion() string {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		if info.Main.Path == "github.com/braintrustdata/braintrust-sdk-go" && isReleaseVersion(info.Main.Version) {
+			return info.Main.Version
+		}
+		for _, dep := range info.Deps {
+			if dep.Path == "github.com/braintrustdata/braintrust-sdk-go" && isReleaseVersion(dep.Version) {
+				return dep.Version
+			}
+		}
+	}
+	return "unknown"
+}
+
+func isReleaseVersion(version string) bool {
+	return version != "" && version != "(devel)"
+}
+
+func resolveEnvironment(explicit *SpanOriginEnvironment) *SpanOriginEnvironment {
+	if explicit != nil {
+		return explicit
+	}
+	if typ := envValue("BRAINTRUST_ENVIRONMENT_TYPE"); typ != "" {
+		return &SpanOriginEnvironment{Type: typ, Name: envValue("BRAINTRUST_ENVIRONMENT_NAME")}
+	}
+	for key, name := range map[string]string{
+		"GITHUB_ACTIONS": "github_actions", "GITLAB_CI": "gitlab_ci", "CIRCLECI": "circleci",
+		"BUILDKITE": "buildkite", "JENKINS_URL": "jenkins", "JENKINS_HOME": "jenkins",
+		"TF_BUILD": "azure_pipelines", "TEAMCITY_VERSION": "teamcity", "TRAVIS": "travis",
+		"BITBUCKET_BUILD_NUMBER": "bitbucket",
+	} {
+		if strings.TrimSpace(os.Getenv(key)) != "" {
+			return &SpanOriginEnvironment{Type: "ci", Name: name}
+		}
+	}
+	if os.Getenv("CI") != "" {
+		return &SpanOriginEnvironment{Type: "ci", Name: "ci"}
+	}
+	for key, name := range map[string]string{
+		"VERCEL": "vercel", "NETLIFY": "netlify", "AWS_LAMBDA_FUNCTION_NAME": "aws_lambda",
+		"AWS_EXECUTION_ENV": "aws_lambda", "K_SERVICE": "cloud_run", "FUNCTION_TARGET": "gcp_functions",
+		"KUBERNETES_SERVICE_HOST": "kubernetes", "ECS_CONTAINER_METADATA_URI": "ecs",
+		"ECS_CONTAINER_METADATA_URI_V4": "ecs", "DYNO": "heroku", "FLY_APP_NAME": "fly",
+		"RAILWAY_ENVIRONMENT": "railway", "RENDER_SERVICE_NAME": "render",
+	} {
+		if strings.TrimSpace(os.Getenv(key)) != "" {
+			return &SpanOriginEnvironment{Type: "server", Name: name}
+		}
+	}
+	return nil
+}
+
+func envValue(key string) string {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+		return value
+	}
+	return braintrustEnvFileValue(key)
+}
+
+func braintrustEnvFileValue(key string) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	for depth := 0; depth <= 64; depth++ {
+		envPath := filepath.Join(dir, ".env.braintrust")
+		if data, err := os.ReadFile(envPath); err == nil {
+			for _, line := range strings.Split(string(data), "\n") {
+				line = strings.TrimSpace(line)
+				if line == "" || strings.HasPrefix(line, "#") {
+					continue
+				}
+				name, value, ok := strings.Cut(line, "=")
+				if !ok || strings.TrimSpace(name) != key {
+					continue
+				}
+				return strings.Trim(strings.TrimSpace(value), `"'`)
+			}
+			return ""
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return ""
 }
 
 // OnEnd is called when a span ends.
@@ -764,7 +901,12 @@ func aiSpanFilterFunc(span sdktrace.ReadOnlySpan) int {
 	for _, attr := range span.Attributes() {
 		attrKey := string(attr.Key)
 		// Skip system attributes that we automatically add to all spans
-		if attrKey == ParentOtelAttrKey || attrKey == orgAttrKey || attrKey == appURLAttrKey {
+		if attrKey == ParentOtelAttrKey ||
+			attrKey == orgAttrKey ||
+			attrKey == appURLAttrKey ||
+			attrKey == contextJSONAttrKey ||
+			attrKey == environmentTypeAttrKey ||
+			attrKey == environmentNameAttrKey {
 			continue
 		}
 		for _, prefix := range aiOtelPrefixes {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -78,6 +78,7 @@ type Config struct {
 	Environment *SpanOriginEnvironment
 }
 
+// SpanOriginEnvironment describes where spans are produced for span-origin provenance.
 type SpanOriginEnvironment struct {
 	Type string
 	Name string
@@ -573,7 +574,11 @@ func spanOriginAttrs(environment *SpanOriginEnvironment) []attribute.KeyValue {
 		if environment.Name != "" {
 			env["name"] = environment.Name
 		}
-		origin["span_origin"].(map[string]any)["environment"] = env
+		spanOrigin, ok := origin["span_origin"].(map[string]any)
+		if !ok {
+			return nil
+		}
+		spanOrigin["environment"] = env
 	}
 	data, err := json.Marshal(origin)
 	if err != nil {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -300,11 +300,9 @@ const ParentOtelAttrKey = "braintrust.parent"
 
 // Internal attribute keys for Braintrust span metadata.
 const (
-	orgAttrKey             = "braintrust.org"
-	appURLAttrKey          = "braintrust.app_url"
-	contextJSONAttrKey     = "braintrust.context_json"
-	environmentTypeAttrKey = "braintrust.environment.type"
-	environmentNameAttrKey = "braintrust.environment.name"
+	orgAttrKey         = "braintrust.org"
+	appURLAttrKey      = "braintrust.app_url"
+	contextJSONAttrKey = "braintrust.context_json"
 )
 
 type contextKey string
@@ -740,12 +738,6 @@ func (sp *spanProcessor) OnEnd(span sdktrace.ReadOnlySpan) {
 func (sp *spanProcessor) addSpanOrigin(span sdktrace.ReadOnlySpan) sdktrace.ReadOnlySpan {
 	overrides := make(map[attribute.Key]string)
 	overrides[contextJSONAttrKey] = spanOriginContextJSON(span, sp.environment)
-	if sp.environment != nil {
-		overrides[environmentTypeAttrKey] = sp.environment.Type
-		if sp.environment.Name != "" {
-			overrides[environmentNameAttrKey] = sp.environment.Name
-		}
-	}
 	return attachmentprocessor.NewTransformedSpan(span, overrides)
 }
 
@@ -960,9 +952,7 @@ func aiSpanFilterFunc(span sdktrace.ReadOnlySpan) int {
 		if attrKey == ParentOtelAttrKey ||
 			attrKey == orgAttrKey ||
 			attrKey == appURLAttrKey ||
-			attrKey == contextJSONAttrKey ||
-			attrKey == environmentTypeAttrKey ||
-			attrKey == environmentNameAttrKey {
+			attrKey == contextJSONAttrKey {
 			continue
 		}
 		for _, prefix := range aiOtelPrefixes {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -595,7 +595,10 @@ func spanOriginContextJSON(span sdktrace.ReadOnlySpan, environment *SpanOriginEn
 			return "{}"
 		}
 		if _, exists := spanOrigin["environment"]; !exists {
-			env := map[string]any{"type": environment.Type}
+			env := map[string]any{}
+			if environment.Type != "" {
+				env["type"] = environment.Type
+			}
 			if environment.Name != "" {
 				env["name"] = environment.Name
 			}
@@ -631,8 +634,10 @@ func resolveEnvironment(explicit *SpanOriginEnvironment) *SpanOriginEnvironment 
 	if explicit != nil {
 		return explicit
 	}
-	if typ := envValue("BRAINTRUST_ENVIRONMENT_TYPE"); typ != "" {
-		return &SpanOriginEnvironment{Type: typ, Name: envValue("BRAINTRUST_ENVIRONMENT_NAME")}
+	typ := envValue("BRAINTRUST_ENVIRONMENT_TYPE")
+	name := envValue("BRAINTRUST_ENVIRONMENT_NAME")
+	if typ != "" || name != "" {
+		return &SpanOriginEnvironment{Type: typ, Name: name}
 	}
 	for key, name := range map[string]string{
 		"GITHUB_ACTIONS": "github_actions", "GITLAB_CI": "gitlab_ci", "CIRCLECI": "circleci",

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -2,6 +2,7 @@ package trace
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -31,6 +32,45 @@ func newTestSession() *auth.Session {
 		"https://www.braintrust.dev",
 		logger.Discard(),
 	)
+}
+
+func TestSpanProcessor_MergesSpanOriginWithContextJSONSetAfterStart(t *testing.T) {
+	assert := assert.New(t)
+
+	tp := sdktrace.NewTracerProvider()
+	exporter := tracetest.NewInMemoryExporter()
+	session := newTestSession()
+	cfg := Config{
+		DefaultProjectID: "late-context-test",
+		Exporter:         exporter,
+		Logger:           logger.Discard(),
+	}
+
+	err := AddSpanProcessor(tp, session, cfg)
+	assert.NoError(err)
+
+	tracer := tp.Tracer("test")
+	_, span := tracer.Start(context.Background(), "late-context")
+	span.SetAttributes(attribute.String(contextJSONAttrKey, `{"metadata":{"source":"late-attribute"}}`))
+	span.End()
+
+	_ = tp.ForceFlush(context.Background())
+	spans := exporter.GetSpans()
+	assert.Len(spans, 1)
+
+	var contextJSON string
+	for _, attr := range spans[0].Attributes {
+		if attr.Key == contextJSONAttrKey {
+			contextJSON = attr.Value.AsString()
+			break
+		}
+	}
+	assert.NotEmpty(contextJSON)
+
+	var context map[string]any
+	assert.NoError(json.Unmarshal([]byte(contextJSON), &context))
+	assert.Equal("late-attribute", context["metadata"].(map[string]any)["source"])
+	assert.Equal("braintrust.sdk.go", context["span_origin"].(map[string]any)["name"])
 }
 
 func TestSpanFilterFunc_WithAttributes(t *testing.T) {

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -74,6 +74,45 @@ func TestSpanProcessor_MergesSpanOriginWithContextJSONSetAfterStart(t *testing.T
 	assert.Equal("braintrust.sdk.go", context["span_origin"].(map[string]any)["name"])
 }
 
+func TestSpanProcessor_PreservesEnvironmentNameWithoutType(t *testing.T) {
+	assert := assert.New(t)
+
+	tp := sdktrace.NewTracerProvider()
+	exporter := tracetest.NewInMemoryExporter()
+	session := newTestSession()
+	cfg := Config{
+		DefaultProjectID: "environment-name-only-test",
+		Exporter:         exporter,
+		Logger:           logger.Discard(),
+		Environment:      &SpanOriginEnvironment{Name: "staging"},
+	}
+
+	err := AddSpanProcessor(tp, session, cfg)
+	assert.NoError(err)
+
+	tracer := tp.Tracer("test")
+	_, span := tracer.Start(context.Background(), "environment-name-only")
+	span.End()
+
+	_ = tp.ForceFlush(context.Background())
+	spans := exporter.GetSpans()
+	assert.Len(spans, 1)
+
+	var contextJSON string
+	for _, attr := range spans[0].Attributes {
+		if attr.Key == contextJSONAttrKey {
+			contextJSON = attr.Value.AsString()
+		}
+	}
+	assert.NotEmpty(contextJSON)
+
+	var context map[string]any
+	assert.NoError(json.Unmarshal([]byte(contextJSON), &context))
+	environment := context["span_origin"].(map[string]any)["environment"].(map[string]any)
+	assert.Equal("staging", environment["name"])
+	assert.NotContains(environment, "type")
+}
+
 func TestSpanFilterFunc_WithAttributes(t *testing.T) {
 	assert := assert.New(t)
 

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -62,8 +62,9 @@ func TestSpanProcessor_MergesSpanOriginWithContextJSONSetAfterStart(t *testing.T
 	for _, attr := range spans[0].Attributes {
 		if attr.Key == contextJSONAttrKey {
 			contextJSON = attr.Value.AsString()
-			break
 		}
+		assert.NotEqual(attribute.Key("braintrust.environment.type"), attr.Key)
+		assert.NotEqual(attribute.Key("braintrust.environment.name"), attr.Key)
 	}
 	assert.NotEmpty(contextJSON)
 


### PR DESCRIPTION
## Summary

Adds span origin provenance to the Go SDK configuration, direct trace setup, and OpenTelemetry export path. Also makes API-key-dependent tests deterministic without local secrets.

## Validation

- env -u GOROOT GOCACHE=/private/tmp/go-build-cache /opt/homebrew/bin/go test ./...
- aggregate git diff --check