### PR TITLE
feat: Remote eval scalar and model parameters

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -100,6 +100,11 @@ type Opts[I, R any] struct {
 	// invocation) and injected into braintrust.span_attributes on every span.
 	// The Braintrust backend uses it to link eval spans back to the triggering context.
 	Generation any
+
+	// Parameters holds resolved parameter values surfaced to the task via
+	// [TaskHooks.Parameters]. The remote eval server sets this from the playground
+	// request; for a direct run it defaults to empty.
+	Parameters Parameters
 }
 
 // CaseProgress contains the result of a single completed evaluation case.
@@ -190,6 +195,11 @@ type RunOpts[I, R any] struct {
 	// invocation) and injected into braintrust.span_attributes on every span.
 	// The Braintrust backend uses it to link eval spans back to the triggering context.
 	Generation any
+
+	// Parameters holds resolved parameter values to surface to the task via
+	// [TaskHooks.Parameters]. The remote eval server sets this from the playground
+	// request; most direct runs leave it empty.
+	Parameters Parameters
 }
 
 // mergeOpts combines an Eval definition with RunOpts into an Opts for
@@ -219,6 +229,7 @@ func mergeOpts[I, R any](ev *Eval[I, R], ro RunOpts[I, R]) Opts[I, R] {
 		OnCaseComplete: ro.OnCaseComplete,
 		SpanParent:     ro.SpanParent,
 		Generation:     ro.Generation,
+		Parameters:     ro.Parameters,
 	}
 }
 
@@ -388,6 +399,7 @@ type eval[I, R any] struct {
 	quiet          bool
 	onCaseComplete func(CaseProgress)
 	generation     any
+	parameters     Parameters
 }
 
 // nextCase is a wrapper for sending cases through a channel.
@@ -416,6 +428,7 @@ func newEval[I, R any](
 	onCaseComplete func(CaseProgress),
 	spanParent bttrace.Parent,
 	generation any,
+	parameters Parameters,
 ) *eval[I, R] {
 	// Build parent span option. Use explicit override if provided (e.g. from
 	// the remote eval server linking spans to a playground), otherwise default
@@ -463,6 +476,7 @@ func newEval[I, R any](
 		quiet:          quiet,
 		onCaseComplete: onCaseComplete,
 		generation:     generation,
+		parameters:     parameters,
 	}
 }
 
@@ -505,6 +519,7 @@ func newEvalOpts[I, R any](ctx context.Context, s *auth.Session, tp *trace.Trace
 		opts.OnCaseComplete,
 		opts.SpanParent,
 		opts.Generation,
+		opts.Parameters,
 	), nil
 }
 
@@ -742,6 +757,7 @@ func (e *eval[I, R]) runTask(ctx context.Context, evalSpan oteltrace.Span, c Cas
 		TrialIndex: trialIndex,
 		TaskSpan:   taskSpan,
 		EvalSpan:   evalSpan,
+		Parameters: e.parameters,
 	}
 
 	// Call task with new signature
@@ -1171,5 +1187,6 @@ func testNewEval[I, R any](
 		nil,              // no callback for tests
 		bttrace.Parent{}, // no parent override
 		nil,              // no generation
+		nil,              // no parameters
 	)
 }

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -1297,7 +1297,7 @@ func TestOnCaseComplete_Callback(t *testing.T) {
 		"proj-callback", "callback-project",
 		cases, task,
 		[]Scorer[testInput, testOutput]{scorer},
-		nil, 1, 1, true, callback, trace.Parent{}, nil,
+		nil, 1, 1, true, callback, trace.Parent{}, nil, nil,
 	)
 
 	result, err := e.run(context.Background())
@@ -1344,7 +1344,7 @@ func TestOnCaseComplete_CallbackOnError(t *testing.T) {
 		"exp-err", "err-experiment",
 		"proj-err", "err-project",
 		cases, task,
-		nil, nil, 1, 1, true, callback, trace.Parent{}, nil,
+		nil, nil, 1, 1, true, callback, trace.Parent{}, nil, nil,
 	)
 
 	_, _ = e.run(context.Background())
@@ -1375,7 +1375,7 @@ func TestOnCaseComplete_NilCallback(t *testing.T) {
 		"exp-nil", "nil-experiment",
 		"proj-nil", "nil-project",
 		cases, task,
-		nil, nil, 1, 1, true, nil, trace.Parent{}, nil,
+		nil, nil, 1, 1, true, nil, trace.Parent{}, nil, nil,
 	)
 
 	result, err := e.run(context.Background())
@@ -1422,7 +1422,7 @@ func TestOnCaseComplete_Parallel(t *testing.T) {
 		"proj-parallel", "parallel-project",
 		cases, task,
 		[]Scorer[testInput, testOutput]{scorer},
-		nil, 4, 1, true, callback, trace.Parent{}, nil,
+		nil, 4, 1, true, callback, trace.Parent{}, nil, nil,
 	)
 
 	result, err := e.run(context.Background())
@@ -1465,7 +1465,7 @@ func TestCaseProgress_IDIsSpanID(t *testing.T) {
 		"exp-id", "id-experiment",
 		"proj-id", "id-project",
 		cases, task,
-		nil, nil, 1, 1, true, callback, trace.Parent{}, nil,
+		nil, nil, 1, 1, true, callback, trace.Parent{}, nil, nil,
 	)
 
 	_, err := e.run(context.Background())
@@ -1506,7 +1506,7 @@ func TestCaseProgress_OriginFromDataset(t *testing.T) {
 		"exp-origin", "origin-experiment",
 		"proj-origin", "origin-project",
 		cases, task,
-		nil, nil, 1, 1, true, callback, trace.Parent{}, nil,
+		nil, nil, 1, 1, true, callback, trace.Parent{}, nil, nil,
 	)
 
 	_, err := e.run(context.Background())
@@ -1543,7 +1543,7 @@ func TestCaseProgress_OriginNilWithoutDatasetID(t *testing.T) {
 		"exp-no-origin", "no-origin-experiment",
 		"proj-no-origin", "no-origin-project",
 		cases, task,
-		nil, nil, 1, 1, true, callback, trace.Parent{}, nil,
+		nil, nil, 1, 1, true, callback, trace.Parent{}, nil, nil,
 	)
 
 	_, err := e.run(context.Background())
@@ -1572,7 +1572,7 @@ func TestResult_ProjectIDAndProjectName(t *testing.T) {
 		"exp-proj", "project-experiment",
 		"proj-abc123", "test-project-name",
 		cases, task,
-		nil, nil, 1, 1, true, nil, trace.Parent{}, nil,
+		nil, nil, 1, 1, true, nil, trace.Parent{}, nil, nil,
 	)
 
 	result, err := e.run(context.Background())
@@ -1760,7 +1760,8 @@ func TestSpanParentOverride(t *testing.T) {
 		[]Scorer[testInput, testOutput]{scorer},
 		nil, 1, 1, true, nil,
 		trace.NewParent(trace.ParentTypePlaygroundID, "pg-999"), // SpanParent override
-		42, // Generation
+		42,  // Generation
+		nil, // Parameters
 	)
 
 	result, err := e.run(context.Background())
@@ -1806,6 +1807,7 @@ func TestSpanParentDefault(t *testing.T) {
 		cases, task, nil, nil,
 		1, 1, true, nil,
 		trace.Parent{}, nil, // no override, no generation
+		nil, // no parameters
 	)
 
 	result, err := e.run(context.Background())

--- a/eval/parameters.go
+++ b/eval/parameters.go
@@ -1,0 +1,90 @@
+package eval
+
+import "encoding/json"
+
+// Parameters holds the resolved parameter values for a single eval run.
+//
+// When an eval is driven from the Braintrust playground via the remote eval
+// server, the controls a user configures (a model picker, a numeric threshold,
+// and so on) arrive as a flat map of values. The server merges them over the
+// declared defaults and hands them to the task on [TaskHooks.Parameters]. For a
+// local run, whatever is passed in [RunOpts.Parameters] is what the task sees.
+//
+// It is a map[string]any, so you can range over it directly, but the typed
+// accessors below are the idiomatic way to read a value: they hide the fact
+// that JSON numbers decode as float64 and never panic on a type mismatch
+// (returning the zero value instead).
+//
+//	model := hooks.Parameters.String("model")
+//	max   := hooks.Parameters.Int("max_length")
+type Parameters map[string]any
+
+// Get returns the raw value for name and whether it was present.
+func (p Parameters) Get(name string) (any, bool) {
+	v, ok := p[name]
+	return v, ok
+}
+
+// Has reports whether a value for name is present.
+func (p Parameters) Has(name string) bool {
+	_, ok := p[name]
+	return ok
+}
+
+// String returns the value for name as a string, or "" if it is absent or not
+// a string.
+func (p Parameters) String(name string) string {
+	if s, ok := p[name].(string); ok {
+		return s
+	}
+	return ""
+}
+
+// Int returns the value for name as an int, or 0 if it is absent or not a
+// number. JSON numbers decode as float64, so those are converted here; int and
+// json.Number are also accepted.
+func (p Parameters) Int(name string) int {
+	switch v := p[name].(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	case json.Number:
+		if i, err := v.Int64(); err == nil {
+			return int(i)
+		}
+		if f, err := v.Float64(); err == nil {
+			return int(f)
+		}
+	}
+	return 0
+}
+
+// Float returns the value for name as a float64, or 0 if it is absent or not a
+// number.
+func (p Parameters) Float(name string) float64 {
+	switch v := p[name].(type) {
+	case float64:
+		return v
+	case int:
+		return float64(v)
+	case int64:
+		return float64(v)
+	case json.Number:
+		if f, err := v.Float64(); err == nil {
+			return f
+		}
+	}
+	return 0
+}
+
+// Bool returns the value for name as a bool, or false if it is absent or not a
+// bool.
+func (p Parameters) Bool(name string) bool {
+	if b, ok := p[name].(bool); ok {
+		return b
+	}
+	return false
+}

--- a/eval/parameters_hooks_test.go
+++ b/eval/parameters_hooks_test.go
@@ -1,0 +1,59 @@
+package eval
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The task must receive the run's resolved parameters via hooks.
+func TestTaskFunc_ReceivesParameters(t *testing.T) {
+	t.Parallel()
+
+	cases := NewDataset([]Case[testInput, testOutput]{
+		{Input: testInput{Value: "test"}},
+	})
+
+	var captured Parameters
+	task := func(ctx context.Context, input testInput, hooks *TaskHooks) (TaskOutput[testOutput], error) {
+		captured = hooks.Parameters
+		return TaskOutput[testOutput]{Value: testOutput{Result: "ok"}}, nil
+	}
+
+	ute := newUnitTestEval(t, cases, task, nil, 1)
+	// Simulate what the run path injects (RunOpts.Parameters -> eval.parameters).
+	ute.eval.parameters = Parameters{"model": "gpt-4o", "max_length": 100.0}
+
+	_, err := ute.eval.run(context.Background())
+	require.NoError(t, err)
+
+	require.NotNil(t, captured, "hooks.Parameters should be set")
+	assert.Equal(t, "gpt-4o", captured.String("model"))
+	assert.Equal(t, 100, captured.Int("max_length"))
+}
+
+// TaskWithHooks adapts a (ctx, input, hooks) -> (R, error) func into a TaskFunc,
+// giving fluent access to parameters without manual TaskOutput wrapping.
+func TestTaskWithHooks_ReadsParameters(t *testing.T) {
+	t.Parallel()
+
+	cases := NewDataset([]Case[testInput, testOutput]{
+		{Input: testInput{Value: "hi"}},
+	})
+
+	var seenModel string
+	task := TaskWithHooks(func(ctx context.Context, input testInput, hooks *TaskHooks) (testOutput, error) {
+		seenModel = hooks.Parameters.String("model")
+		return testOutput{Result: input.Value + ":" + seenModel}, nil
+	})
+
+	ute := newUnitTestEval(t, cases, task, nil, 1)
+	ute.eval.parameters = Parameters{"model": "rule-based"}
+
+	_, err := ute.eval.run(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, "rule-based", seenModel)
+}

--- a/eval/parameters_test.go
+++ b/eval/parameters_test.go
@@ -1,0 +1,122 @@
+package eval
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParameters_String(t *testing.T) {
+	p := Parameters{"model": "gpt-4o", "n": 5.0}
+
+	if got := p.String("model"); got != "gpt-4o" {
+		t.Errorf("String(model) = %q, want %q", got, "gpt-4o")
+	}
+	if got := p.String("missing"); got != "" {
+		t.Errorf("String(missing) = %q, want empty", got)
+	}
+	if got := p.String("n"); got != "" {
+		t.Errorf("String(n) = %q, want empty for type mismatch", got)
+	}
+}
+
+func TestParameters_Int(t *testing.T) {
+	// JSON numbers decode as float64; also accept int and json.Number.
+	p := Parameters{
+		"float":  100.0,
+		"int":    42,
+		"number": json.Number("7"),
+		"str":    "nope",
+	}
+
+	if got := p.Int("float"); got != 100 {
+		t.Errorf("Int(float) = %d, want 100", got)
+	}
+	if got := p.Int("int"); got != 42 {
+		t.Errorf("Int(int) = %d, want 42", got)
+	}
+	if got := p.Int("number"); got != 7 {
+		t.Errorf("Int(number) = %d, want 7", got)
+	}
+	if got := p.Int("str"); got != 0 {
+		t.Errorf("Int(str) = %d, want 0 for type mismatch", got)
+	}
+	if got := p.Int("missing"); got != 0 {
+		t.Errorf("Int(missing) = %d, want 0", got)
+	}
+}
+
+func TestParameters_Float(t *testing.T) {
+	p := Parameters{
+		"float":  1.5,
+		"int":    3,
+		"number": json.Number("2.25"),
+		"str":    "nope",
+	}
+
+	if got := p.Float("float"); got != 1.5 {
+		t.Errorf("Float(float) = %v, want 1.5", got)
+	}
+	if got := p.Float("int"); got != 3.0 {
+		t.Errorf("Float(int) = %v, want 3.0", got)
+	}
+	if got := p.Float("number"); got != 2.25 {
+		t.Errorf("Float(number) = %v, want 2.25", got)
+	}
+	if got := p.Float("str"); got != 0 {
+		t.Errorf("Float(str) = %v, want 0 for type mismatch", got)
+	}
+}
+
+func TestParameters_Bool(t *testing.T) {
+	p := Parameters{"yes": true, "no": false, "str": "true"}
+
+	if got := p.Bool("yes"); got != true {
+		t.Errorf("Bool(yes) = %v, want true", got)
+	}
+	if got := p.Bool("no"); got != false {
+		t.Errorf("Bool(no) = %v, want false", got)
+	}
+	if got := p.Bool("str"); got != false {
+		t.Errorf("Bool(str) = %v, want false for type mismatch", got)
+	}
+	if got := p.Bool("missing"); got != false {
+		t.Errorf("Bool(missing) = %v, want false", got)
+	}
+}
+
+func TestParameters_HasAndGet(t *testing.T) {
+	p := Parameters{"model": "gpt-4o"}
+
+	if !p.Has("model") {
+		t.Error("Has(model) = false, want true")
+	}
+	if p.Has("missing") {
+		t.Error("Has(missing) = true, want false")
+	}
+
+	v, ok := p.Get("model")
+	if !ok || v != "gpt-4o" {
+		t.Errorf("Get(model) = (%v, %v), want (gpt-4o, true)", v, ok)
+	}
+	if _, ok := p.Get("missing"); ok {
+		t.Error("Get(missing) ok = true, want false")
+	}
+}
+
+// A nil Parameters map must be safe to read from (local runs pass no parameters).
+func TestParameters_NilSafe(t *testing.T) {
+	var p Parameters
+
+	if got := p.String("model"); got != "" {
+		t.Errorf("nil String = %q, want empty", got)
+	}
+	if got := p.Int("n"); got != 0 {
+		t.Errorf("nil Int = %d, want 0", got)
+	}
+	if p.Has("model") {
+		t.Error("nil Has = true, want false")
+	}
+	if _, ok := p.Get("model"); ok {
+		t.Error("nil Get ok = true, want false")
+	}
+}

--- a/eval/task.go
+++ b/eval/task.go
@@ -23,6 +23,12 @@ type TaskHooks struct {
 	Metadata   Metadata // Case metadata
 	Tags       []string // Case tags
 	TrialIndex int      // The index of the current trial (0-based)
+
+	// Parameters holds the resolved parameter values for this run. When the eval
+	// is driven from a Braintrust playground via the remote eval server, these
+	// are the values a user configured for the run (with declared defaults
+	// merged in). Empty for a local run unless set via [RunOpts.Parameters].
+	Parameters Parameters
 }
 
 // TaskOutput wraps the output value from a task.
@@ -57,6 +63,21 @@ type TaskResult[I, R any] struct {
 func T[I, R any](fn func(ctx context.Context, input I) (R, error)) TaskFunc[I, R] {
 	return func(ctx context.Context, input I, hooks *TaskHooks) (TaskOutput[R], error) {
 		val, err := fn(ctx, input)
+		return TaskOutput[R]{Value: val}, err
+	}
+}
+
+// TaskWithHooks is like [T] but also passes the [TaskHooks], for tasks that need
+// to read parameters, metadata, or tags. It handles the [TaskOutput] wrapping so
+// you can return a plain value.
+//
+//	task := eval.TaskWithHooks(func(ctx context.Context, input string, hooks *eval.TaskHooks) (string, error) {
+//		model := hooks.Parameters.String("model")
+//		return classify(input, model), nil
+//	})
+func TaskWithHooks[I, R any](fn func(ctx context.Context, input I, hooks *TaskHooks) (R, error)) TaskFunc[I, R] {
+	return func(ctx context.Context, input I, hooks *TaskHooks) (TaskOutput[R], error) {
+		val, err := fn(ctx, input, hooks)
 		return TaskOutput[R]{Value: val}, err
 	}
 }

--- a/examples/internal/eval-server/README.md
+++ b/examples/internal/eval-server/README.md
@@ -8,8 +8,9 @@ Results (outputs + scores) stream back to the UI and are recorded as an experime
 
 - Starting a remote eval server with `server.New(...)` and `srv.Start()`
 - Registering an evaluator (`food-classifier`, a `string → string` task) with two scorers
-  (`exact_match`, `valid_category`) and a UI-visible `model` parameter
-- Driving that evaluator from a Braintrust **Playground** and viewing streamed results
+  (`exact_match`, `valid_category`) and a `model` parameter the task actually reads
+- Driving that evaluator from a Braintrust **Playground**, changing the `model` parameter to
+  alter task behavior, and viewing streamed results
 
 The task is intentionally rule-based (simple string matching), so the example needs **no
 LLM API key** — the focus is the remote-eval wiring, not the model.
@@ -58,6 +59,9 @@ is needed** as long as your browser is on the same machine as the server.
    Create remote eval source**. Give it a name and set the URL to `http://localhost:8300`.
 2. **Add the task**: open a **Playground**, choose **+ Task → Remote eval**, and pick
    `food-classifier`. The `model` control (from the eval's parameter schema) appears here.
+   It isn't cosmetic — the task reads it: leave it at `rule-based` (lenient substring matching,
+   so `"A crisp red apple"` → `fruit`) or set it to `strict` (only an exact single word matches,
+   so the descriptive rows below fall through to `unknown`). Try both and watch `exact_match` move.
 3. **Attach a dataset**: the playground supplies the cases (the eval's own dataset is not
    used). Click **Select a dataset → Create new dataset**, then add rows manually or upload
    a JSON/CSV file. Each row needs an `input` and an `expected` field:

--- a/examples/internal/eval-server/main.go
+++ b/examples/internal/eval-server/main.go
@@ -15,6 +15,8 @@ import (
 	"log"
 	"strings"
 
+	"go.opentelemetry.io/otel/attribute"
+
 	"github.com/braintrustdata/braintrust-sdk-go/eval"
 	"github.com/braintrustdata/braintrust-sdk-go/server"
 )
@@ -29,17 +31,24 @@ func main() {
 		server.WithNoAuth(),
 	)
 
-	// Define a simple task: classify food items.
-	classifyTask := eval.T(func(ctx context.Context, input string) (string, error) {
-		input = strings.ToLower(input)
-		switch {
-		case strings.Contains(input, "apple") || strings.Contains(input, "banana"):
-			return "fruit", nil
-		case strings.Contains(input, "carrot") || strings.Contains(input, "lettuce"):
-			return "vegetable", nil
-		default:
-			return "unknown", nil
+	// Define the task with TaskWithHooks so it can read the "model" parameter
+	// the user selects in the playground. Two modes are supported:
+	//
+	//   - "rule-based" (default): lenient substring matching.
+	//   - "strict":               only an exact, single-word match counts.
+	//
+	// Selecting a different model in the playground changes how inputs classify.
+	classifyTask := eval.TaskWithHooks(func(ctx context.Context, input string, hooks *eval.TaskHooks) (string, error) {
+		model := hooks.Parameters.String("model")
+
+		// Record the model on the task span so it's visible in the trace.
+		hooks.TaskSpan.SetAttributes(attribute.String("model", model))
+
+		normalized := strings.ToLower(strings.TrimSpace(input))
+		if model == "strict" {
+			return classifyStrict(normalized), nil
 		}
+		return classifyRuleBased(normalized), nil
 	})
 
 	// Define a scorer: exact match.
@@ -72,14 +81,15 @@ func main() {
 		ProjectName: "go-sdk-examples",
 	}
 
-	// Register with the server.
+	// Register with the server. The "model" parameter is a model-picker control
+	// in the playground; its selected value reaches the task via hooks.Parameters.
 	server.RegisterEval(srv, foodClassifier, server.RegisterEvalOpts{
 		Parameters: &server.Parameters{
 			Schema: map[string]server.ParameterDef{
 				"model": {
-					Type:        "string",
+					Type:        "model",
 					Default:     "rule-based",
-					Description: "Classification model to use",
+					Description: "Classification strategy: rule-based (lenient) or strict",
 				},
 			},
 		},
@@ -91,4 +101,30 @@ func main() {
 	log.Printf("Health check: http://localhost:8300/")
 	log.Printf("List evals:   http://localhost:8300/list")
 	log.Fatal(srv.Start())
+}
+
+// classifyRuleBased matches on substrings, so descriptive phrases still classify
+// (e.g. "a crisp red apple" -> fruit).
+func classifyRuleBased(input string) string {
+	switch {
+	case strings.Contains(input, "apple") || strings.Contains(input, "banana"):
+		return "fruit"
+	case strings.Contains(input, "carrot") || strings.Contains(input, "lettuce"):
+		return "vegetable"
+	default:
+		return "unknown"
+	}
+}
+
+// classifyStrict only classifies an exact, single-word input, so descriptive
+// phrases fall through to "unknown" — a deliberately stricter strategy.
+func classifyStrict(input string) string {
+	switch input {
+	case "apple", "banana":
+		return "fruit"
+	case "carrot", "lettuce":
+		return "vegetable"
+	default:
+		return "unknown"
+	}
 }

--- a/server/register.go
+++ b/server/register.go
@@ -221,6 +221,7 @@ func (r *registeredEvalImpl[I, R]) run(ctx context.Context, cfg *evalRunConfig) 
 		OnCaseComplete: onComplete,
 		SpanParent:     spanParent,
 		Generation:     generation,
+		Parameters:     resolveParameters(r.opts.Parameters, req.Parameters),
 	})
 
 	// Flush traces before sending summary so the UI can poll for scores immediately.
@@ -316,4 +317,31 @@ func (r *registeredEvalImpl[I, R]) parseInlineData(raw json.RawMessage) (eval.Da
 	}
 
 	return eval.NewDataset(cases), nil
+}
+
+// resolveParameters merges the values selected in the playground request over the
+// evaluator's declared defaults, producing the resolved set surfaced to the task
+// via eval.TaskHooks.Parameters. Request values win; unknown keys pass through
+// (matching the other SDKs). Returns nil when there is nothing to surface.
+func resolveParameters(schema *Parameters, req map[string]any) eval.Parameters {
+	if schema == nil && len(req) == 0 {
+		return nil
+	}
+
+	resolved := make(eval.Parameters)
+	if schema != nil {
+		for name, def := range schema.Schema {
+			if def.Default != nil {
+				resolved[name] = def.Default
+			}
+		}
+	}
+	for name, val := range req {
+		resolved[name] = val
+	}
+
+	if len(resolved) == 0 {
+		return nil
+	}
+	return resolved
 }

--- a/server/register_test.go
+++ b/server/register_test.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveParameters_DefaultsOnly(t *testing.T) {
+	schema := &Parameters{
+		Schema: map[string]ParameterDef{
+			"model":      {Type: "model", Default: "gpt-4o"},
+			"max_length": {Type: "number", Default: 100.0},
+		},
+	}
+
+	// No request values -> declared defaults apply.
+	got := resolveParameters(schema, nil)
+
+	assert.Equal(t, "gpt-4o", got.String("model"))
+	assert.Equal(t, 100, got.Int("max_length"))
+}
+
+func TestResolveParameters_RequestOverridesDefault(t *testing.T) {
+	schema := &Parameters{
+		Schema: map[string]ParameterDef{
+			"model": {Type: "model", Default: "gpt-4o"},
+		},
+	}
+
+	got := resolveParameters(schema, map[string]any{"model": "claude"})
+
+	assert.Equal(t, "claude", got.String("model"))
+}
+
+func TestResolveParameters_PassesThroughUnknownKeys(t *testing.T) {
+	// A value not in the schema is still delivered (matches Ruby's merge semantics).
+	got := resolveParameters(nil, map[string]any{"adhoc": "value"})
+
+	assert.Equal(t, "value", got.String("adhoc"))
+}
+
+func TestResolveParameters_EmptyIsNil(t *testing.T) {
+	assert.Nil(t, resolveParameters(nil, nil))
+}

--- a/server/server.go
+++ b/server/server.go
@@ -224,12 +224,7 @@ func (s *Server) handleList(w http.ResponseWriter, _ *http.Request) {
 		if params := e.parameters(); params != nil {
 			wireSchema := make(map[string]wireParameterDef, len(params.Schema))
 			for k, v := range params.Schema {
-				wireSchema[k] = wireParameterDef{
-					Type:        "data",
-					Schema:      schemaField{Type: v.Type},
-					Default:     v.Default,
-					Description: v.Description,
-				}
+				wireSchema[k] = toWireParameterDef(v)
 			}
 			info.Parameters = &parametersMeta{
 				Type:   "braintrust.staticParameters",

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -136,6 +136,53 @@ func TestListEndpoint_WithParameters(t *testing.T) {
 	assert.Equal(t, "Model to use", modelParam.Description)
 }
 
+func TestListEndpoint_ModelParameter(t *testing.T) {
+	srv := New(WithNoAuth())
+
+	task := eval.T(func(ctx context.Context, input string) (string, error) {
+		return input, nil
+	})
+	scorer := eval.NewScorer("score", func(ctx context.Context, r eval.TaskResult[string, string]) (eval.Scores, error) {
+		return eval.S(1.0), nil
+	})
+
+	RegisterEval(srv, &eval.Eval[string, string]{
+		Name:    "model-eval",
+		Task:    task,
+		Scorers: []eval.Scorer[string, string]{scorer},
+	}, RegisterEvalOpts{
+		Parameters: &Parameters{
+			Schema: map[string]ParameterDef{
+				"model": {Type: "model", Default: "gpt-4o", Description: "Model picker"},
+			},
+		},
+	})
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/list")
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+
+	var body map[string]json.RawMessage
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+
+	var info struct {
+		Parameters *parametersMeta `json:"parameters"`
+	}
+	require.NoError(t, json.Unmarshal(body["model-eval"], &info))
+	require.NotNil(t, info.Parameters)
+
+	// A model parameter uses the union's "model" shape: top-level type "model",
+	// no nested schema object.
+	modelParam := info.Parameters.Schema["model"]
+	assert.Equal(t, "model", modelParam.Type)
+	assert.Nil(t, modelParam.Schema, "model params must not carry a nested schema")
+	assert.Equal(t, "gpt-4o", modelParam.Default)
+	assert.Equal(t, "Model picker", modelParam.Description)
+}
+
 func TestEvalEndpoint_MissingName(t *testing.T) {
 	srv := New(WithNoAuth())
 	ts := httptest.NewServer(srv.Handler())

--- a/server/types.go
+++ b/server/types.go
@@ -16,6 +16,11 @@ type EvalRequest struct {
 	// ProjectID overrides the project ID (optional).
 	ProjectID string `json:"project_id,omitempty"`
 
+	// Parameters holds the resolved parameter values selected in the playground
+	// (a flat name->value map). Merged over declared defaults and surfaced to the
+	// task via eval.TaskHooks.Parameters.
+	Parameters map[string]any `json:"parameters,omitempty"`
+
 	// Parent specifies the parent span for tracing (optional).
 	Parent *ParentInfo `json:"parent,omitempty"`
 }
@@ -77,17 +82,41 @@ type parametersMeta struct {
 }
 
 // wireParameterDef is the wire format for a parameter in the dev server protocol.
-// Each parameter is wrapped with type "data" and a nested schema object.
+// Scalar ("data") parameters are wrapped with type "data" and a nested schema
+// object; "model" (and "prompt") parameters use their own top-level type and omit
+// the nested schema.
 type wireParameterDef struct {
-	Type        string      `json:"type"`
-	Schema      schemaField `json:"schema"`
-	Default     any         `json:"default,omitempty"`
-	Description string      `json:"description,omitempty"`
+	Type        string       `json:"type"`
+	Schema      *schemaField `json:"schema,omitempty"`
+	Default     any          `json:"default,omitempty"`
+	Description string       `json:"description,omitempty"`
 }
 
 // schemaField is the inner schema for a wire parameter definition.
 type schemaField struct {
 	Type string `json:"type"`
+}
+
+// toWireParameterDef converts a user-declared ParameterDef into its dev-server
+// wire form. "model" and "prompt" parameters map to their own top-level type
+// with no nested schema; everything else is a scalar "data" parameter carrying a
+// nested JSON-schema-ish {type} object.
+func toWireParameterDef(def ParameterDef) wireParameterDef {
+	switch def.Type {
+	case "model", "prompt":
+		return wireParameterDef{
+			Type:        def.Type,
+			Default:     def.Default,
+			Description: def.Description,
+		}
+	default:
+		return wireParameterDef{
+			Type:        "data",
+			Schema:      &schemaField{Type: def.Type},
+			Default:     def.Default,
+			Description: def.Description,
+		}
+	}
 }
 
 // progressEvent is an SSE progress event sent per evaluation case.


### PR DESCRIPTION
# Remote eval parameters (scalar & model)

Parameters let a remote eval accept per-run configuration from the Braintrust
playground. You declare a set of named controls (a model picker, a numeric
threshold, a toggle) when you register an evaluator; the value a user selects in
the playground is delivered to your task at run time. This adds support for **scalar** and **model** parameters. (`prompt` parameters and passing parameters to scorers is not added here.)

Before this change the server could *advertise* a parameter schema, but the
selected value went nowhere. This closes that loop.

## What it's used for

Tuning an eval's behavior without redeploying — switching which model a task
calls, adjusting a matching threshold, flipping a strategy — and comparing the
results across settings directly in the playground.

## How you use it

**1. Declare the parameters** when registering the evaluator:

```go
server.RegisterEval(srv, myEval, server.RegisterEvalOpts{
    Parameters: &server.Parameters{
        Schema: map[string]server.ParameterDef{
            "model":      {Type: "model", Default: "gpt-4o-mini", Description: "Model to use"},
            "max_length": {Type: "number", Default: 100},
        },
    },
})
```

**2. Read them in the task** with `TaskWithHooks`. Values arrive on typed 
`hooks.Parameters`:

```go
task := eval.TaskWithHooks(func(ctx context.Context, input string, hooks *eval.TaskHooks) (string, error) {
    model := hooks.Parameters.String("model")   // resolved value; declared default already merged in
    max   := hooks.Parameters.Int("max_length") // JSON numbers coerced for you
    return classify(input, model, max), nil
})
```

Accessors: `String`, `Int`, `Float`, `Bool`, plus `Has(name)` and `Get(name)`.
`Parameters` is a `map[string]any` underneath, so you can still range over it for
advanced cases. When the playground omits a value, the task receives the declared
`Default`.

## Trying the example

The [`eval-server`](examples/internal/eval-server/) example declares a `model`
parameter and changes its classification behavior based on the selected value.

```bash
cd examples && mise exec -- go run ./internal/eval-server
```

Drive it from a playground and toggle the `model` control between `rule-based`
and `strict` to watch the outputs change. Full walkthrough in its
[README](examples/internal/eval-server/README.md).

## Design notes

- **Typed accessors over a raw map.** JSON decodes every number as `float64`, so
  a bare `map[string]any` would force fragile, panic-prone type assertions at
  every read. The typed getters mirror the standard library (`url.Values`,
  `flag`) and keep task code fluent and safe.
- **Defaults merged server-side.** The server overlays the playground's selected
  values on top of the declared defaults before handing them to the task, so a
  task always sees a resolved value (matching the other SDKs).
- **Additive and non-breaking.** All new surface is either a new symbol or a new
  field on an existing struct; existing evals and tasks are unaffected.
