### PR TITLE
fix(trace): normalize Google token usage metrics

### DIFF
--- a/trace/contrib/adk/golden_test.go
+++ b/trace/contrib/adk/golden_test.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/adk/session"
 	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/functiontool"
+	"google.golang.org/adk/tool/geminitool"
 	"google.golang.org/genai"
 
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -555,6 +556,41 @@ func TestToolUse(t *testing.T) {
 		"model span should be child of agent span")
 }
 
+func TestGoogleSearchUsage(t *testing.T) {
+	ctx, tp, exporter := setupGoldenTest(t)
+
+	sid := "session-google-search"
+	r := newGoldenRunner(ctx, t, tp, sid, llmagent.Config{
+		Name:                  "search_agent",
+		Instruction:           "Use Google Search to answer the user's question.",
+		Tools:                 []tool.Tool{geminitool.GoogleSearch{}},
+		GenerateContentConfig: &genai.GenerateContentConfig{MaxOutputTokens: 500},
+	})
+
+	msg := genai.NewContentFromText("Search the web for the current stable Go release and name its major and minor version.", genai.RoleUser)
+	responses := runAndCollectFinal(ctx, t, r, sid, msg, agent.RunConfig{})
+	text := assertFinalResponse(t, responses)
+	t.Logf("Response: %s", text)
+
+	spans := assertSpansExist(t, exporter)
+	var modelSpan *oteltest.Span
+	for i := range spans {
+		if spans[i].Name() == "call_llm" {
+			modelSpan = &spans[i]
+			break
+		}
+	}
+	require.NotNil(t, modelSpan)
+
+	metrics := modelSpan.Metrics()
+	assert.Equal(t, float64(157), metrics["prompt_tokens"])
+	assert.Equal(t, float64(295), metrics["completion_tokens"])
+	assert.Equal(t, float64(239), metrics["completion_reasoning_tokens"])
+	assert.Equal(t, float64(452), metrics["tokens"])
+	assert.Equal(t, metrics["tokens"], metrics["prompt_tokens"]+metrics["completion_tokens"])
+	assert.NotContains(t, metrics, "tool_use_prompt_token_count")
+}
+
 func TestReasoning(t *testing.T) {
 	ctx, tp, exporter := setupGoldenTest(t)
 
@@ -579,5 +615,28 @@ func TestReasoning(t *testing.T) {
 	text = assertFinalResponse(t, responses)
 	t.Logf("Follow-up response: %s", text)
 
-	assertSpansExist(t, exporter)
+	spans := assertSpansExist(t, exporter)
+	var modelSpans []*oteltest.Span
+	for i := range spans {
+		if spans[i].Name() == "call_llm" {
+			modelSpans = append(modelSpans, &spans[i])
+		}
+	}
+	require.Len(t, modelSpans, 2)
+
+	firstMetrics := modelSpans[0].Metrics()
+	assert.Equal(t, float64(47), firstMetrics["prompt_tokens"])
+	assert.Equal(t, float64(1608), firstMetrics["completion_tokens"])
+	assert.Equal(t, float64(765), firstMetrics["completion_reasoning_tokens"])
+	assert.Equal(t, float64(1655), firstMetrics["tokens"])
+	assert.Equal(t, firstMetrics["tokens"], firstMetrics["prompt_tokens"]+firstMetrics["completion_tokens"])
+	assert.NotContains(t, firstMetrics, "tool_use_prompt_token_count")
+	assert.False(t, modelSpans[0].HasAttr("gen_ai.usage.prompt_tokens"))
+
+	secondMetrics := modelSpans[1].Metrics()
+	assert.Equal(t, float64(1475), secondMetrics["prompt_tokens"])
+	assert.Equal(t, float64(1627), secondMetrics["completion_tokens"])
+	assert.Equal(t, float64(900), secondMetrics["completion_reasoning_tokens"])
+	assert.Equal(t, float64(3102), secondMetrics["tokens"])
+	assert.Equal(t, secondMetrics["tokens"], secondMetrics["prompt_tokens"]+secondMetrics["completion_tokens"])
 }

--- a/trace/contrib/adk/testdata/cassettes/TestGoogleSearchUsage.yaml
+++ b/trace/contrib/adk/testdata/cassettes/TestGoogleSearchUsage.yaml
@@ -1,0 +1,150 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 318
+        transfer_encoding: []
+        trailer: {}
+        host: generativelanguage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"contents":[{"parts":[{"text":"Search the web for the current stable Go release and name its major and minor version."}],"role":"user"}],"generationConfig":{"maxOutputTokens":500},"systemInstruction":{"parts":[{"text":"Use Google Search to answer the user's question."}],"role":"user"},"tools":[{"googleSearch":{}}]}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - google-adk/0.3.0 gl-go/1.26.5
+                - google-genai-sdk/1.41.0 gl-go/go1.26.5
+            X-Goog-Api-Client:
+                - google-adk/0.3.0 gl-go/1.26.5
+                - google-genai-sdk/1.41.0 gl-go/go1.26.5
+            X-Server-Timeout:
+                - "30"
+        url: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "candidates": [
+                {
+                  "content": {
+                    "parts": [
+                      {
+                        "text": "The current stable Go release is Go 1.26.5.\nIts major version is 1, and its minor version is 26."
+                      }
+                    ],
+                    "role": "model"
+                  },
+                  "finishReason": "STOP",
+                  "index": 0,
+                  "groundingMetadata": {
+                    "searchEntryPoint": {
+                      "renderedContent": "\u003cstyle\u003e\n.container {\n  align-items: center;\n  border-radius: 8px;\n  display: flex;\n  font-family: Google Sans, Roboto, sans-serif;\n  font-size: 14px;\n  line-height: 20px;\n  padding: 8px 12px;\n}\n.chip {\n  display: inline-block;\n  border: solid 1px;\n  border-radius: 16px;\n  min-width: 14px;\n  padding: 5px 16px;\n  text-align: center;\n  user-select: none;\n  margin: 0 8px;\n  -webkit-tap-highlight-color: transparent;\n}\n.carousel {\n  overflow: auto;\n  scrollbar-width: none;\n  white-space: nowrap;\n  margin-right: -12px;\n}\n.headline {\n  display: flex;\n  margin-right: 4px;\n}\n.gradient-container {\n  position: relative;\n}\n.gradient {\n  position: absolute;\n  transform: translate(3px, -9px);\n  height: 36px;\n  width: 9px;\n}\n@media (prefers-color-scheme: light) {\n  .container {\n    background-color: #fafafa;\n    box-shadow: 0 0 0 1px #0000000f;\n  }\n  .headline-label {\n    color: #1f1f1f;\n  }\n  .chip {\n    background-color: #ffffff;\n    border-color: #d2d2d2;\n    color: #5e5e5e;\n    text-decoration: none;\n  }\n  .chip:hover {\n    background-color: #f2f2f2;\n  }\n  .chip:focus {\n    background-color: #f2f2f2;\n  }\n  .chip:active {\n    background-color: #d8d8d8;\n    border-color: #b6b6b6;\n  }\n  .logo-dark {\n    display: none;\n  }\n  .gradient {\n    background: linear-gradient(90deg, #fafafa 15%, #fafafa00 100%);\n  }\n}\n@media (prefers-color-scheme: dark) {\n  .container {\n    background-color: #1f1f1f;\n    box-shadow: 0 0 0 1px #ffffff26;\n  }\n  .headline-label {\n    color: #fff;\n  }\n  .chip {\n    background-color: #2c2c2c;\n    border-color: #3c4043;\n    color: #fff;\n    text-decoration: none;\n  }\n  .chip:hover {\n    background-color: #353536;\n  }\n  .chip:focus {\n    background-color: #353536;\n  }\n  .chip:active {\n    background-color: #464849;\n    border-color: #53575b;\n  }\n  .logo-light {\n    display: none;\n  }\n  .gradient {\n    background: linear-gradient(90deg, #1f1f1f 15%, #1f1f1f00 100%);\n  }\n}\n\u003c/style\u003e\n\u003cdiv class=\"container\"\u003e\n  \u003cdiv class=\"headline\"\u003e\n    \u003csvg class=\"logo-light\" width=\"18\" height=\"18\" viewBox=\"9 9 35 35\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"\u003e\n      \u003cpath fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M42.8622 27.0064C42.8622 25.7839 42.7525 24.6084 42.5487 23.4799H26.3109V30.1568H35.5897C35.1821 32.3041 33.9596 34.1222 32.1258 35.3448V39.6864H37.7213C40.9814 36.677 42.8622 32.2571 42.8622 27.0064V27.0064Z\" fill=\"#4285F4\"/\u003e\n      \u003cpath fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M26.3109 43.8555C30.9659 43.8555 34.8687 42.3195 37.7213 39.6863L32.1258 35.3447C30.5898 36.3792 28.6306 37.0061 26.3109 37.0061C21.8282 37.0061 18.0195 33.9811 16.6559 29.906H10.9194V34.3573C13.7563 39.9841 19.5712 43.8555 26.3109 43.8555V43.8555Z\" fill=\"#34A853\"/\u003e\n      \u003cpath fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M16.6559 29.8904C16.3111 28.8559 16.1074 27.7588 16.1074 26.6146C16.1074 25.4704 16.3111 24.3733 16.6559 23.3388V18.8875H10.9194C9.74388 21.2072 9.06992 23.8247 9.06992 26.6146C9.06992 29.4045 9.74388 32.022 10.9194 34.3417L15.3864 30.8621L16.6559 29.8904V29.8904Z\" fill=\"#FBBC05\"/\u003e\n      \u003cpath fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M26.3109 16.2386C28.85 16.2386 31.107 17.1164 32.9095 18.8091L37.8466 13.8719C34.853 11.082 30.9659 9.3736 26.3109 9.3736C19.5712 9.3736 13.7563 13.245 10.9194 18.8875L16.6559 23.3388C18.0195 19.2636 21.8282 16.2386 26.3109 16.2386V16.2386Z\" fill=\"#EA4335\"/\u003e\n    \u003c/svg\u003e\n    \u003csvg class=\"logo-dark\" width=\"18\" height=\"18\" viewBox=\"0 0 48 48\" xmlns=\"http://www.w3.org/2000/svg\"\u003e\n      \u003ccircle cx=\"24\" cy=\"23\" fill=\"#FFF\" r=\"22\"/\u003e\n      \u003cpath d=\"M33.76 34.26c2.75-2.56 4.49-6.37 4.49-11.26 0-.89-.08-1.84-.29-3H24.01v5.99h8.03c-.4 2.02-1.5 3.56-3.07 4.56v.75l3.91 2.97h.88z\" fill=\"#4285F4\"/\u003e\n      \u003cpath d=\"M15.58 25.77A8.845 8.845 0 0 0 24 31.86c1.92 0 3.62-.46 4.97-1.31l4.79 3.71C31.14 36.7 27.65 38 24 38c-5.93 0-11.01-3.4-13.45-8.36l.17-1.01 4.06-2.85h.8z\" fill=\"#34A853\"/\u003e\n      \u003cpath d=\"M15.59 20.21a8.864 8.864 0 0 0 0 5.58l-5.03 3.86c-.98-2-1.53-4.25-1.53-6.64 0-2.39.55-4.64 1.53-6.64l1-.22 3.81 2.98.22 1.08z\" fill=\"#FBBC05\"/\u003e\n      \u003cpath d=\"M24 14.14c2.11 0 4.02.75 5.52 1.98l4.36-4.36C31.22 9.43 27.81 8 24 8c-5.93 0-11.01 3.4-13.45 8.36l5.03 3.85A8.86 8.86 0 0 1 24 14.14z\" fill=\"#EA4335\"/\u003e\n    \u003c/svg\u003e\n    \u003cdiv class=\"gradient-container\"\u003e\u003cdiv class=\"gradient\"\u003e\u003c/div\u003e\u003c/div\u003e\n  \u003c/div\u003e\n  \u003cdiv class=\"carousel\"\u003e\n    \u003ca class=\"chip\" href=\"https://vertexaisearch.cloud.google.com/grounding-api-redirect/AUZIYQEIy2tUqJToBHZAVd65PQL_NYlzV2etW7IoBnR5w_EV4Ywjc8zSJs2H7LLVmO8sGr5ZY8i43DVrTcqG_je_wdOvX1sDhLoTwlFbam43YxUyD0HJA5Px35dKx4urdEmTjQH0_fmY3EFzBLBGoeolNy1bV1--tb4RWo-q_8laa0VVod-Wid0vXmqK_EOvT3u7fbOUqd_TtK3ELutJ0ThKQ2cN7BkEzbU_oKftXQmbYFWYmg==\"\u003ecurrent stable Go release major minor version\u003c/a\u003e\n    \u003ca class=\"chip\" href=\"https://vertexaisearch.cloud.google.com/grounding-api-redirect/AUZIYQEP64YAgUOxVAYijXekBGvgLUxlO6Cw_3RxKZ5FOhmCVC4KpbgqnB6FLOTIzQtlJxG7UghaHJ_OTBjKBWCdi4tsS2otFVQWWn3DPxyyHi8Onksn0a4ms15diWosNPw77bdLLS3wFS3cko6rfDpyWMmGD2hjSTjfnDjUdyMLgA8wEBrVtvDynYZq5j5QNw16S1AtiNQ7IdrYB1yRow==\"\u003elatest stable Go release\u003c/a\u003e\n  \u003c/div\u003e\n\u003c/div\u003e\n"
+                    },
+                    "groundingChunks": [
+                      {
+                        "web": {
+                          "uri": "https://vertexaisearch.cloud.google.com/grounding-api-redirect/AUZIYQGF6Hen3kCffLvzw9cWUXa8s7JaEIrKVNy5m-9F6n60GylZ6cXSRdrQ01aeIQNBgJ7XaGd9aQZ82poQTYI51Dg7C0xTK2o7XBXYmLRtggyQBTnO8e3m8FJUaSO-msEBlI6y6BvBz2iK1B9wetCagHajifU=",
+                          "title": "wikipedia.org"
+                        }
+                      },
+                      {
+                        "web": {
+                          "uri": "https://vertexaisearch.cloud.google.com/grounding-api-redirect/AUZIYQF5TOex5VPe2MvsBj-JVFEF27LotK-XemXc0qKBMCc4Y-Eey1LqmIvsubr4KXn3Mx0nUCbpTRewRdMhcgcgNDerRkZFvihq9I-iFSBxRgQCaPDOoDA=",
+                          "title": "endoflife.date"
+                        }
+                      }
+                    ],
+                    "groundingSupports": [
+                      {
+                        "segment": {
+                          "startIndex": 41,
+                          "endIndex": 43,
+                          "text": "5."
+                        },
+                        "groundingChunkIndices": [
+                          0,
+                          1
+                        ]
+                      },
+                      {
+                        "segment": {
+                          "startIndex": 44,
+                          "endIndex": 96,
+                          "text": "Its major version is 1, and its minor version is 26."
+                        },
+                        "groundingChunkIndices": [
+                          0,
+                          1
+                        ]
+                      }
+                    ],
+                    "webSearchQueries": [
+                      "current stable Go release major minor version",
+                      "latest stable Go release"
+                    ]
+                  }
+                }
+              ],
+              "usageMetadata": {
+                "promptTokenCount": 30,
+                "candidatesTokenCount": 56,
+                "totalTokenCount": 452,
+                "promptTokensDetails": [
+                  {
+                    "modality": "TEXT",
+                    "tokenCount": 30
+                  }
+                ],
+                "toolUsePromptTokenCount": 127,
+                "toolUsePromptTokensDetails": [
+                  {
+                    "modality": "TEXT",
+                    "tokenCount": 127
+                  }
+                ],
+                "thoughtsTokenCount": 239,
+                "serviceTier": "standard"
+              },
+              "modelVersion": "gemini-2.5-flash",
+              "responseId": "YR9-aoKEIaGKjrEP8sLx4Qk"
+            }
+        headers:
+            Alt-Svc:
+                - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+            Content-Type:
+                - application/json; charset=UTF-8
+            Date:
+                - Thu, 13 Aug 2026 19:47:47 GMT
+            Server:
+                - scaffolding on HTTPServer2
+            Server-Timing:
+                - gfet4t7; dur=2404
+            Vary:
+                - Origin
+                - X-Origin
+                - Referer
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Gemini-Service-Tier:
+                - standard
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 2.58332925s

--- a/trace/contrib/adk/traceadk.go
+++ b/trace/contrib/adk/traceadk.go
@@ -375,16 +375,9 @@ func (c *callbacksImpl) AfterModel(ctx agent.CallbackContext, resp *model.LLMRes
 			c.logger.Debug("Failed to set braintrust.output_json", "error", err)
 		}
 
-		// Record token usage if available
 		if resp.UsageMetadata != nil {
-			if resp.UsageMetadata.PromptTokenCount > 0 {
-				span.SetAttributes(attribute.Int64("gen_ai.usage.prompt_tokens", int64(resp.UsageMetadata.PromptTokenCount)))
-			}
-			if resp.UsageMetadata.CandidatesTokenCount > 0 {
-				span.SetAttributes(attribute.Int64("gen_ai.usage.completion_tokens", int64(resp.UsageMetadata.CandidatesTokenCount)))
-			}
-			if resp.UsageMetadata.TotalTokenCount > 0 {
-				span.SetAttributes(attribute.Int64("gen_ai.usage.total_tokens", int64(resp.UsageMetadata.TotalTokenCount)))
+			if metricsErr := internal.SetJSONAttr(span, "braintrust.metrics", usageMetrics(resp.UsageMetadata)); metricsErr != nil {
+				c.logger.Debug("Failed to set braintrust.metrics", "error", metricsErr)
 			}
 		}
 
@@ -395,6 +388,27 @@ func (c *callbacksImpl) AfterModel(ctx agent.CallbackContext, resp *model.LLMRes
 	}
 
 	return nil, nil
+}
+
+// usageMetrics normalizes Google UsageMetadata to Braintrust metrics.
+func usageMetrics(usage *genai.GenerateContentResponseUsageMetadata) map[string]int64 {
+	if usage == nil {
+		return map[string]int64{}
+	}
+
+	metrics := map[string]int64{
+		"prompt_tokens":     int64(usage.PromptTokenCount) + int64(usage.ToolUsePromptTokenCount),
+		"completion_tokens": int64(usage.CandidatesTokenCount) + int64(usage.ThoughtsTokenCount),
+		"tokens":            int64(usage.TotalTokenCount),
+	}
+	if usage.ThoughtsTokenCount > 0 {
+		metrics["completion_reasoning_tokens"] = int64(usage.ThoughtsTokenCount)
+	}
+	if usage.CachedContentTokenCount > 0 {
+		metrics["prompt_cached_tokens"] = int64(usage.CachedContentTokenCount)
+	}
+
+	return metrics
 }
 
 // BeforeTool is called before executing a tool.

--- a/trace/contrib/adk/traceadk_test.go
+++ b/trace/contrib/adk/traceadk_test.go
@@ -22,6 +22,39 @@ import (
 	"github.com/braintrustdata/braintrust-sdk-go/logger"
 )
 
+func TestUsageMetrics(t *testing.T) {
+	t.Run("aggregates_reasoning_and_tool_use_tokens", func(t *testing.T) {
+		usage := &genai.GenerateContentResponseUsageMetadata{
+			PromptTokenCount:        12,
+			ToolUsePromptTokenCount: 3,
+			CandidatesTokenCount:    9,
+			ThoughtsTokenCount:      6,
+			TotalTokenCount:         30,
+			CachedContentTokenCount: 4,
+		}
+
+		assert.Equal(t, map[string]int64{
+			"prompt_tokens":               15,
+			"completion_tokens":           15,
+			"completion_reasoning_tokens": 6,
+			"tokens":                      30,
+			"prompt_cached_tokens":        4,
+		}, usageMetrics(usage))
+	})
+
+	t.Run("preserves_core_zero_values_and_omits_unavailable_details", func(t *testing.T) {
+		assert.Equal(t, map[string]int64{
+			"prompt_tokens":     0,
+			"completion_tokens": 0,
+			"tokens":            0,
+		}, usageMetrics(&genai.GenerateContentResponseUsageMetadata{}))
+	})
+
+	t.Run("nil_usage", func(t *testing.T) {
+		assert.Empty(t, usageMetrics(nil))
+	})
+}
+
 func TestCleanupJSON(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/trace/contrib/genai/generatecontent.go
+++ b/trace/contrib/genai/generatecontent.go
@@ -338,49 +338,33 @@ func (gt *generateContentTracer) handleResponse(span trace.Span, raw map[string]
 	return nil
 }
 
-// parseUsageTokens parses the usage tokens from Gemini API responses
+// parseUsageTokens normalizes Gemini UsageMetadata to Braintrust metrics.
 func parseUsageTokens(usage map[string]interface{}) map[string]int64 {
 	metrics := make(map[string]int64)
 
-	if usage == nil {
-		return metrics
+	hasPromptTokens, promptTokens := internal.ToInt64(usage["promptTokenCount"])
+	hasToolUsePromptTokens, toolUsePromptTokens := internal.ToInt64(usage["toolUsePromptTokenCount"])
+	if hasPromptTokens || hasToolUsePromptTokens {
+		metrics["prompt_tokens"] = promptTokens + toolUsePromptTokens
 	}
 
-	for k, v := range usage {
-		if ok, i := internal.ToInt64(v); ok {
-			switch k {
-			case "promptTokenCount":
-				metrics["prompt_tokens"] = i
-			case "candidatesTokenCount":
-				metrics["completion_tokens"] = i
-			case "totalTokenCount":
-				metrics["tokens"] = i
-			case "cachedContentTokenCount":
-				metrics["prompt_cached_tokens"] = i
-			case "thoughtsTokenCount":
-				metrics["completion_reasoning_tokens"] = i
-			default:
-				// Keep other fields as-is for future-proofing
-				// Convert camelCase to snake_case for consistency
-				snakeKey := camelToSnake(k)
-				metrics[snakeKey] = i
-			}
-		}
+	hasCandidateTokens, candidateTokens := internal.ToInt64(usage["candidatesTokenCount"])
+	hasThoughtTokens, thoughtTokens := internal.ToInt64(usage["thoughtsTokenCount"])
+	if hasCandidateTokens || hasThoughtTokens {
+		metrics["completion_tokens"] = candidateTokens + thoughtTokens
+	}
+	if hasThoughtTokens {
+		metrics["completion_reasoning_tokens"] = thoughtTokens
+	}
+
+	if ok, totalTokens := internal.ToInt64(usage["totalTokenCount"]); ok {
+		metrics["tokens"] = totalTokens
+	}
+	if ok, cachedTokens := internal.ToInt64(usage["cachedContentTokenCount"]); ok {
+		metrics["prompt_cached_tokens"] = cachedTokens
 	}
 
 	return metrics
-}
-
-// camelToSnake converts camelCase to snake_case
-func camelToSnake(s string) string {
-	var result strings.Builder
-	for i, r := range s {
-		if i > 0 && r >= 'A' && r <= 'Z' {
-			result.WriteRune('_')
-		}
-		result.WriteRune(r)
-	}
-	return strings.ToLower(result.String())
 }
 
 // Ensure our tracer implements the shared interface

--- a/trace/contrib/genai/testdata/cassettes/TestGenerateContentWithCodeExecution.yaml
+++ b/trace/contrib/genai/testdata/cassettes/TestGenerateContentWithCodeExecution.yaml
@@ -1,0 +1,113 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 194
+        transfer_encoding: []
+        trailer: {}
+        host: generativelanguage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"contents":[{"parts":[{"text":"Calculate the sum of the first five prime numbers using Python, then explain the result."}],"role":"user"}],"generationConfig":{},"tools":[{"codeExecution":{}}]}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - google-genai-sdk/1.41.0 gl-go/go1.26.5
+            X-Goog-Api-Client:
+                - google-genai-sdk/1.41.0 gl-go/go1.26.5
+            X-Server-Timeout:
+                - "30"
+        url: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "candidates": [
+                {
+                  "content": {
+                    "parts": [
+                      {
+                        "executableCode": {
+                          "language": "PYTHON",
+                          "code": "prime_numbers = [2, 3, 5, 7, 11]\nsum_of_primes = sum(prime_numbers)\nprint(f\"The sum of the first five prime numbers is: {sum_of_primes}\")\n"
+                        }
+                      },
+                      {
+                        "codeExecutionResult": {
+                          "outcome": "OUTCOME_OK",
+                          "output": "The sum of the first five prime numbers is: 28\n"
+                        }
+                      },
+                      {
+                        "text": "The first five prime numbers are 2, 3, 5, 7, and 11.\n\nUsing Python, the sum of these numbers is calculated as:\n2 + 3 + 5 + 7 + 11 = 28\n\nThe result of the calculation is **28**."
+                      }
+                    ],
+                    "role": "model"
+                  },
+                  "finishReason": "STOP",
+                  "index": 0
+                }
+              ],
+              "usageMetadata": {
+                "promptTokenCount": 18,
+                "candidatesTokenCount": 121,
+                "totalTokenCount": 545,
+                "promptTokensDetails": [
+                  {
+                    "modality": "TEXT",
+                    "tokenCount": 18
+                  }
+                ],
+                "toolUsePromptTokenCount": 247,
+                "toolUsePromptTokensDetails": [
+                  {
+                    "modality": "TEXT",
+                    "tokenCount": 247
+                  }
+                ],
+                "thoughtsTokenCount": 159,
+                "serviceTier": "standard"
+              },
+              "modelVersion": "gemini-2.5-flash",
+              "responseId": "Yx1-apbFNZ33jrEP3dfm4A0"
+            }
+        headers:
+            Alt-Svc:
+                - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+            Content-Type:
+                - application/json; charset=UTF-8
+            Date:
+                - Thu, 13 Aug 2026 19:39:17 GMT
+            Server:
+                - scaffolding on HTTPServer2
+            Server-Timing:
+                - gfet4t7; dur=1967
+            Vary:
+                - Origin
+                - X-Origin
+                - Referer
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Gemini-Service-Tier:
+                - standard
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 2.204086084s

--- a/trace/contrib/genai/testdata/cassettes/TestStreamingGenerateContentWithCodeExecution.yaml
+++ b/trace/contrib/genai/testdata/cassettes/TestStreamingGenerateContentWithCodeExecution.yaml
@@ -1,0 +1,63 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 169
+        transfer_encoding: []
+        trailer: {}
+        host: generativelanguage.googleapis.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"contents":[{"parts":[{"text":"Use Python to calculate 123 times 456, then explain the result."}],"role":"user"}],"generationConfig":{},"tools":[{"codeExecution":{}}]}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - google-genai-sdk/1.41.0 gl-go/go1.26.5
+            X-Goog-Api-Client:
+                - google-genai-sdk/1.41.0 gl-go/go1.26.5
+            X-Server-Timeout:
+                - "30"
+        url: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"executableCode\": {\"language\": \"PYTHON\",\"code\": \"result = 123 * 456\\nprint(f'{result=}')\\n\"}}],\"role\": \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 20,\"candidatesTokenCount\": 19,\"totalTokenCount\": 76,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 20}],\"thoughtsTokenCount\": 37,\"serviceTier\": \"standard\"},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"gR1-aqX8GvKZ-8YPuMPJ4Q8\"}\r\n\r\ndata: {\"candidates\": [{\"content\": {\"parts\": [{\"codeExecutionResult\": {\"outcome\": \"OUTCOME_OK\",\"output\": \"result=56088\\n\"}}],\"role\": \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 20,\"candidatesTokenCount\": 19,\"totalTokenCount\": 76,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 20}],\"thoughtsTokenCount\": 37,\"serviceTier\": \"standard\"},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"gR1-aqX8GvKZ-8YPuMPJ4Q8\"}\r\n\r\ndata: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"The product\"}],\"role\": \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 20,\"candidatesTokenCount\": 21,\"totalTokenCount\": 163,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 20}],\"toolUsePromptTokenCount\": 85,\"toolUsePromptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 85}],\"thoughtsTokenCount\": 37,\"serviceTier\": \"standard\"},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"gR1-aqX8GvKZ-8YPuMPJ4Q8\"}\r\n\r\ndata: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \" of 123 multiplied by 456 is 56,\"}],\"role\": \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 20,\"candidatesTokenCount\": 37,\"totalTokenCount\": 179,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 20}],\"toolUsePromptTokenCount\": 85,\"toolUsePromptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 85}],\"thoughtsTokenCount\": 37,\"serviceTier\": \"standard\"},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"gR1-aqX8GvKZ-8YPuMPJ4Q8\"}\r\n\r\ndata: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"088. This means that if you have 123 groups of 456 items, or vice versa, the total number of items is 56,088.\"}],\"role\": \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 20,\"candidatesTokenCount\": 77,\"totalTokenCount\": 219,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 20}],\"toolUsePromptTokenCount\": 85,\"toolUsePromptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 85}],\"thoughtsTokenCount\": 37,\"serviceTier\": \"standard\"},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"gR1-aqX8GvKZ-8YPuMPJ4Q8\"}\r\n\r\n"
+        headers:
+            Alt-Svc:
+                - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+            Content-Disposition:
+                - attachment
+            Content-Type:
+                - text/event-stream
+            Date:
+                - Thu, 13 Aug 2026 19:39:46 GMT
+            Server:
+                - scaffolding on HTTPServer2
+            Server-Timing:
+                - gfet4t7; dur=666
+            Vary:
+                - Origin
+                - X-Origin
+                - Referer
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 823.194208ms

--- a/trace/contrib/genai/tracegenai_test.go
+++ b/trace/contrib/genai/tracegenai_test.go
@@ -200,10 +200,73 @@ func TestGenerateContentWithThinking(t *testing.T) {
 	}, metadata["thinkingConfig"])
 
 	metrics := ts.Metrics()
-	assert.Greater(metrics["completion_reasoning_tokens"], float64(0))
+	assert.Equal(float64(47), metrics["prompt_tokens"])
+	assert.Equal(float64(1711), metrics["completion_tokens"])
+	assert.Equal(float64(874), metrics["completion_reasoning_tokens"])
+	assert.Equal(float64(1758), metrics["tokens"])
+	assert.Equal(metrics["tokens"], metrics["prompt_tokens"]+metrics["completion_tokens"])
 	assert.NotContains(metrics, "thoughts_token_count")
-	assert.Greater(metrics["prompt_tokens"], float64(0))
-	assert.Greater(metrics["tokens"], float64(0))
+}
+
+func TestGenerateContentWithCodeExecution(t *testing.T) {
+	client, exporter := setUpTest(t)
+
+	resp, err := client.Models.GenerateContent(
+		context.Background(),
+		"gemini-2.5-flash",
+		genai.Text("Calculate the sum of the first five prime numbers using Python, then explain the result."),
+		&genai.GenerateContentConfig{
+			Tools: []*genai.Tool{{CodeExecution: &genai.ToolCodeExecution{}}},
+		},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Contains(t, resp.Text(), "28")
+
+	ts := exporter.FlushOne()
+	ts.AssertNameIs("generate_content")
+	assert.Equal(t, codes.Unset, ts.Status().Code)
+
+	metrics := ts.Metrics()
+	assert.Equal(t, float64(265), metrics["prompt_tokens"])
+	assert.Equal(t, float64(280), metrics["completion_tokens"])
+	assert.Equal(t, float64(159), metrics["completion_reasoning_tokens"])
+	assert.Equal(t, float64(545), metrics["tokens"])
+	assert.Equal(t, metrics["tokens"], metrics["prompt_tokens"]+metrics["completion_tokens"])
+	assert.NotContains(t, metrics, "tool_use_prompt_token_count")
+}
+
+func TestStreamingGenerateContentWithCodeExecution(t *testing.T) {
+	client, exporter := setUpTest(t)
+
+	iter := client.Models.GenerateContentStream(
+		context.Background(),
+		"gemini-2.5-flash",
+		genai.Text("Use Python to calculate 123 times 456, then explain the result."),
+		&genai.GenerateContentConfig{
+			Tools: []*genai.Tool{{CodeExecution: &genai.ToolCodeExecution{}}},
+		},
+	)
+
+	var fullText string
+	for resp, err := range iter {
+		require.NoError(t, err)
+		fullText += resp.Text()
+	}
+	assert.Contains(t, fullText, "56,088")
+
+	ts := exporter.FlushOne()
+	ts.AssertNameIs("generate_content")
+	assert.Equal(t, codes.Unset, ts.Status().Code)
+
+	metrics := ts.Metrics()
+	assert.Equal(t, float64(105), metrics["prompt_tokens"])
+	assert.Equal(t, float64(114), metrics["completion_tokens"])
+	assert.Equal(t, float64(37), metrics["completion_reasoning_tokens"])
+	assert.Equal(t, float64(219), metrics["tokens"])
+	assert.Equal(t, metrics["tokens"], metrics["prompt_tokens"]+metrics["completion_tokens"])
+	assert.NotContains(t, metrics, "tool_use_prompt_token_count")
 }
 
 func TestParseUsageTokens(t *testing.T) {
@@ -237,12 +300,44 @@ func TestParseUsageTokens(t *testing.T) {
 		assert.Equal(t, int64(80), metrics["prompt_cached_tokens"])
 	})
 
-	t.Run("nil_usage", func(t *testing.T) {
-		metrics := parseUsageTokens(nil)
-		assert.Empty(t, metrics)
+	t.Run("aggregates_reasoning_and_tool_use_tokens", func(t *testing.T) {
+		usage := map[string]interface{}{
+			"promptTokenCount":        float64(12),
+			"toolUsePromptTokenCount": float64(3),
+			"candidatesTokenCount":    float64(9),
+			"thoughtsTokenCount":      float64(6),
+			"totalTokenCount":         float64(30),
+		}
+
+		metrics := parseUsageTokens(usage)
+
+		assert.Equal(t, int64(15), metrics["prompt_tokens"])
+		assert.Equal(t, int64(15), metrics["completion_tokens"])
+		assert.Equal(t, int64(6), metrics["completion_reasoning_tokens"])
+		assert.Equal(t, int64(30), metrics["tokens"])
+		assert.NotContains(t, metrics, "tool_use_prompt_token_count")
 	})
 
-	t.Run("unknown_field", func(t *testing.T) {
+	t.Run("preserves_reported_zero_values", func(t *testing.T) {
+		usage := map[string]interface{}{
+			"promptTokenCount":        float64(0),
+			"toolUsePromptTokenCount": float64(0),
+			"candidatesTokenCount":    float64(0),
+			"thoughtsTokenCount":      float64(0),
+			"totalTokenCount":         float64(0),
+		}
+
+		metrics := parseUsageTokens(usage)
+
+		assert.Equal(t, map[string]int64{
+			"prompt_tokens":               0,
+			"completion_tokens":           0,
+			"completion_reasoning_tokens": 0,
+			"tokens":                      0,
+		}, metrics)
+	})
+
+	t.Run("omits_unavailable_values", func(t *testing.T) {
 		usage := map[string]interface{}{
 			"promptTokenCount":  float64(10),
 			"someNewTokenCount": float64(5),
@@ -250,9 +345,13 @@ func TestParseUsageTokens(t *testing.T) {
 
 		metrics := parseUsageTokens(usage)
 
-		assert.Equal(t, int64(10), metrics["prompt_tokens"])
-		// Unknown field should be converted to snake_case
-		assert.Equal(t, int64(5), metrics["some_new_token_count"])
+		assert.Equal(t, map[string]int64{"prompt_tokens": 10}, metrics)
+		assert.NotContains(t, metrics, "some_new_token_count")
+	})
+
+	t.Run("nil_usage", func(t *testing.T) {
+		metrics := parseUsageTokens(nil)
+		assert.Empty(t, metrics)
 	})
 }
 
@@ -387,26 +486,6 @@ func TestIsStreamingPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {
 			assert.Equal(t, tt.streaming, isStreamingPath(tt.path))
-		})
-	}
-}
-
-func TestCamelToSnake(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"promptTokenCount", "prompt_token_count"},
-		{"cachedContentTokenCount", "cached_content_token_count"},
-		{"totalTokenCount", "total_token_count"},
-		{"simpleWord", "simple_word"},
-		{"ABC", "a_b_c"},
-	}
-
-	for _, test := range tests {
-		t.Run(test.input, func(t *testing.T) {
-			result := camelToSnake(test.input)
-			assert.Equal(t, test.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
Make sure our google integrations align with token counts from https://ai.google.dev/api/generate-content#UsageMetadata properly.

resolves https://linear.app/braintrustdata/issue/SDK-111/adk-normalize-google-reasoning-and-tool-use-token-totals
resolves https://linear.app/braintrustdata/issue/SDK-112/genai-normalize-reasoning-and-tool-use-token-totals

Fixes #170
Fixes #188
Fixes #189