### PR TITLE
fix(anthropic): align tracing with instrumentation spec

### DIFF
--- a/btx/btx_test.go
+++ b/btx/btx_test.go
@@ -20,12 +20,7 @@ import (
 
 // skipSpecs lists spec display names that should be skipped.
 // Add specs here when they test features not yet supported by the Go SDK.
-var skipSpecs = map[string]string{
-	// Prompt caching metrics (prompt_cache_creation_5m_tokens etc.) are not yet
-	// tracked by the Go SDK's Anthropic instrumentation.
-	"anthropic/prompt_caching_5m": "prompt caching metrics not yet supported",
-	"anthropic/prompt_caching_1h": "prompt caching metrics not yet supported",
-}
+var skipSpecs = map[string]string{}
 
 // specRoot is set by TestMain after fetching specs.
 var specRoot string

--- a/btx/testdata/cassettes/anthropic/prompt_caching_1h.yaml
+++ b/btx/testdata/cassettes/anthropic/prompt_caching_1h.yaml
@@ -1,0 +1,106 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 6552
+        transfer_encoding: []
+        trailer: {}
+        host: ""
+        remote_addr: ""
+        request_uri: ""
+        body: '{"max_tokens":128,"messages":[{"content":[{"text":"What is the capital of France?","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-5-20250929","temperature":0,"system":[{"text":"[cache buster: go-btx c215c33a]\nReference material (stable, cached with a 1 hour TTL):\n\nThe following is a condensed atlas of capital cities. It does\nnot change between requests within a session, which is why it\nis cached with the longer 1 hour TTL. Consult it before\nanswering.\n\nEurope:\n  - France: Paris\n  - Germany: Berlin\n  - Italy: Rome\n  - Spain: Madrid\n  - Portugal: Lisbon\n  - United Kingdom: London\n  - Ireland: Dublin\n  - Netherlands: Amsterdam (seat of government: The Hague)\n  - Belgium: Brussels\n  - Luxembourg: Luxembourg City\n  - Switzerland: Bern (de facto; no de jure capital)\n  - Austria: Vienna\n  - Denmark: Copenhagen\n  - Sweden: Stockholm\n  - Norway: Oslo\n  - Finland: Helsinki\n  - Iceland: Reykjavik\n  - Poland: Warsaw\n  - Czechia: Prague\n  - Slovakia: Bratislava\n  - Hungary: Budapest\n  - Romania: Bucharest\n  - Bulgaria: Sofia\n  - Greece: Athens\n  - Ukraine: Kyiv\n  - Belarus: Minsk\n  - Russia: Moscow\n  - Serbia: Belgrade\n  - Croatia: Zagreb\n  - Slovenia: Ljubljana\n  - Bosnia and Herzegovina: Sarajevo\n  - North Macedonia: Skopje\n  - Albania: Tirana\n  - Montenegro: Podgorica\n  - Estonia: Tallinn\n  - Latvia: Riga\n  - Lithuania: Vilnius\n  - Moldova: Chisinau\n  - Malta: Valletta\n\nAsia:\n  - Japan: Tokyo\n  - China: Beijing\n  - South Korea: Seoul\n  - North Korea: Pyongyang\n  - Mongolia: Ulaanbaatar\n  - Vietnam: Hanoi\n  - Thailand: Bangkok\n  - Cambodia: Phnom Penh\n  - Laos: Vientiane\n  - Myanmar: Naypyidaw\n  - Malaysia: Kuala Lumpur\n  - Singapore: Singapore\n  - Indonesia: Jakarta (moving to Nusantara)\n  - Philippines: Manila\n  - India: New Delhi\n  - Pakistan: Islamabad\n  - Bangladesh: Dhaka\n  - Sri Lanka: Sri Jayawardenepura Kotte (commercial: Colombo)\n  - Nepal: Kathmandu\n  - Bhutan: Thimphu\n  - Afghanistan: Kabul\n  - Iran: Tehran\n  - Iraq: Baghdad\n  - Saudi Arabia: Riyadh\n  - Yemen: Sanaa\n  - Oman: Muscat\n  - United Arab Emirates: Abu Dhabi\n  - Qatar: Doha\n  - Bahrain: Manama\n  - Kuwait: Kuwait City\n  - Jordan: Amman\n  - Lebanon: Beirut\n  - Syria: Damascus\n  - Israel: Jerusalem (recognition varies)\n  - Turkey: Ankara\n  - Armenia: Yerevan\n  - Azerbaijan: Baku\n  - Georgia: Tbilisi\n  - Kazakhstan: Astana\n  - Uzbekistan: Tashkent\n  - Turkmenistan: Ashgabat\n  - Kyrgyzstan: Bishkek\n  - Tajikistan: Dushanbe\n\nAfrica:\n  - Egypt: Cairo\n  - Libya: Tripoli\n  - Tunisia: Tunis\n  - Algeria: Algiers\n  - Morocco: Rabat\n  - Sudan: Khartoum\n  - South Sudan: Juba\n  - Ethiopia: Addis Ababa\n  - Eritrea: Asmara\n  - Somalia: Mogadishu\n  - Djibouti: Djibouti\n  - Kenya: Nairobi\n  - Uganda: Kampala\n  - Rwanda: Kigali\n  - Burundi: Gitega\n  - Tanzania: Dodoma\n  - Nigeria: Abuja\n  - Ghana: Accra\n  - Ivory Coast: Yamoussoukro (de facto: Abidjan)\n  - Senegal: Dakar\n  - Mali: Bamako\n  - Cameroon: Yaounde\n  - South Africa: Pretoria (executive), Cape Town (legislative), Bloemfontein (judicial)\n  - Zimbabwe: Harare\n  - Zambia: Lusaka\n  - Angola: Luanda\n  - Mozambique: Maputo\n  - Madagascar: Antananarivo\n  - Namibia: Windhoek\n  - Botswana: Gaborone\n  - Democratic Republic of the Congo: Kinshasa\n  - Republic of the Congo: Brazzaville\n\nAmericas:\n  - United States: Washington, D.C.\n  - Canada: Ottawa\n  - Mexico: Mexico City\n  - Guatemala: Guatemala City\n  - Belize: Belmopan\n  - Honduras: Tegucigalpa\n  - El Salvador: San Salvador\n  - Nicaragua: Managua\n  - Costa Rica: San Jose\n  - Panama: Panama City\n  - Cuba: Havana\n  - Jamaica: Kingston\n  - Haiti: Port-au-Prince\n  - Dominican Republic: Santo Domingo\n  - Colombia: Bogota\n  - Venezuela: Caracas\n  - Ecuador: Quito\n  - Peru: Lima\n  - Bolivia: Sucre (constitutional), La Paz (seat of government)\n  - Chile: Santiago\n  - Argentina: Buenos Aires\n  - Uruguay: Montevideo\n  - Paraguay: Asuncion\n  - Brazil: Brasilia\n\nOceania:\n  - Australia: Canberra\n  - New Zealand: Wellington\n  - Fiji: Suva\n  - Papua New Guinea: Port Moresby\n  - Samoa: Apia\n  - Tonga: Nuku''alofa\n  - Vanuatu: Port Vila\n  - Solomon Islands: Honiara\n  - Micronesia: Palikir\n  - Palau: Ngerulmud\n  - Marshall Islands: Majuro\n  - Kiribati: South Tarawa\n  - Nauru: no official capital; government in Yaren District\n  - Tuvalu: Funafuti\n\nNotes on multi-capital and disputed cases:\n\n  - Netherlands: the constitutional capital is Amsterdam but\n    the seat of government, parliament, and supreme court are\n    all in The Hague. Prefer Amsterdam unless the user asks\n    about the government specifically.\n  - South Africa: three capitals split by branch. Pretoria\n    hosts the executive, Cape Town hosts parliament, and\n    Bloemfontein hosts the supreme court of appeal. No single\n    city is \"the\" capital.\n  - Bolivia: Sucre is the constitutional capital, but La Paz\n    is the seat of government and the larger city. Either\n    answer is defensible; list both when asked.\n  - Ivory Coast: Yamoussoukro has been the official capital\n    since 1983, but Abidjan remains the economic hub and de\n    facto administrative center for most purposes.\n  - Sri Lanka: Sri Jayawardenepura Kotte is the legislative\n    capital. Colombo is the commercial capital and by far the\n    more commonly referenced city.\n  - Switzerland: Bern is the de facto capital (the seat of\n    the federal authorities), but Swiss law does not\n    designate any city as \"the capital\".\n  - Nauru: has no designated capital. Government offices are\n    in the Yaren District, which is often listed as the\n    capital by convention.\n  - Israel: Jerusalem is the declared capital, but\n    international recognition of that status is not\n    universal. Many embassies are in Tel Aviv.\n  - Palestine: de jure capital is East Jerusalem; de facto\n    administrative center is Ramallah. Both appear in\n    official usage.\n  - Taiwan: Taipei is the capital of the Republic of China.\n    Recognition as a sovereign state varies by country.\n  - Kosovo: Pristina is the capital of the Republic of\n    Kosovo. Recognition as a sovereign state varies by\n    country.\n  - Somaliland: Hargeisa is the capital of the self-declared\n    Republic of Somaliland, which is not widely recognized.\n    Somalia, which claims the territory, has its capital at\n    Mogadishu.\n\nEnd of reference material.\n","cache_control":{"ttl":"1h","type":"ephemeral"},"type":"text"}]}'
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Anthropic-Beta:
+                - extended-cache-ttl-2025-04-11
+            Anthropic-Version:
+                - "2023-06-01"
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Anthropic/Go 1.23.0
+            X-Stainless-Arch:
+                - arm64
+            X-Stainless-Lang:
+                - go
+            X-Stainless-Os:
+                - MacOS
+            X-Stainless-Package-Version:
+                - 1.23.0
+            X-Stainless-Retry-Count:
+                - "0"
+            X-Stainless-Runtime:
+                - go
+            X-Stainless-Runtime-Version:
+                - go1.26.5
+            X-Stainless-Timeout:
+                - "600"
+        url: https://api.anthropic.com/v1/messages
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"model":"claude-sonnet-4-5-20250929","id":"msg_011Ce1LoVbrDHdBWf6a23dfZ","type":"message","role":"assistant","content":[{"type":"text","text":"The capital of France is **Paris**."}],"stop_reason":"end_turn","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":12,"cache_creation_input_tokens":1993,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":1993},"output_tokens":11,"service_tier":"standard","inference_geo":"not_available"}}'
+        headers:
+            Anthropic-Ratelimit-Input-Tokens-Limit:
+                - "10000000"
+            Anthropic-Ratelimit-Input-Tokens-Remaining:
+                - "9999000"
+            Anthropic-Ratelimit-Input-Tokens-Reset:
+                - "2026-08-13T20:00:39Z"
+            Anthropic-Ratelimit-Output-Tokens-Limit:
+                - "2000000"
+            Anthropic-Ratelimit-Output-Tokens-Remaining:
+                - "2000000"
+            Anthropic-Ratelimit-Output-Tokens-Reset:
+                - "2026-08-13T20:00:39Z"
+            Anthropic-Ratelimit-Requests-Limit:
+                - "20000"
+            Anthropic-Ratelimit-Requests-Remaining:
+                - "19999"
+            Anthropic-Ratelimit-Requests-Reset:
+                - "2026-08-13T20:00:38Z"
+            Anthropic-Ratelimit-Tokens-Limit:
+                - "12000000"
+            Anthropic-Ratelimit-Tokens-Remaining:
+                - "11999000"
+            Anthropic-Ratelimit-Tokens-Reset:
+                - "2026-08-13T20:00:39Z"
+            Anthropic-Workspace-Id:
+                - wrkspc_018bFG1FgNVWqx5pthtdGTzS
+            Cf-Cache-Status:
+                - DYNAMIC
+            Cf-Ray:
+                - a2aa4e9cadf5ccd9-YYZ
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 13 Aug 2026 20:00:39 GMT
+            Request-Id:
+                - req_011Ce1LoUvfqGrb6b5G7cjj1
+            Server:
+                - cloudflare
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload
+            Traceresponse:
+                - 00-6c3a2d2aec8fe874d92e33e4c6a29302-88c38d0f7613cc9a-01
+            Vary:
+                - Accept-Encoding
+            X-Robots-Tag:
+                - none
+        status: 200 OK
+        code: 200
+        duration: 1.779392833s

--- a/btx/testdata/cassettes/anthropic/prompt_caching_5m.yaml
+++ b/btx/testdata/cassettes/anthropic/prompt_caching_5m.yaml
@@ -1,0 +1,104 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 6115
+        transfer_encoding: []
+        trailer: {}
+        host: ""
+        remote_addr: ""
+        request_uri: ""
+        body: '{"max_tokens":128,"messages":[{"content":[{"text":"What is the capital of France?","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-5-20250929","temperature":0,"system":[{"text":"[cache buster: go-btx 9adabb4e]\nYou are a helpful assistant answering questions about world\ngeography. Follow the operating guidelines below on every\nresponse. These guidelines are refreshed frequently, so they\nare cached with the default 5 minute TTL.\n\n1. Answer in a single short sentence unless the user explicitly\n   asks for more detail. Do not add preambles like \"Sure, here\n   is the answer\" or \"Great question\". Just answer.\n2. Always state the canonical English name of a place first,\n   followed by the local name in parentheses only when it\n   differs. Do not include pronunciation guides.\n3. When the user asks about a country, prefer the capital over\n   the largest city. When the user asks about a region, prefer\n   the administrative center. When the user asks about a\n   continent, prefer a widely recognized reference city and\n   note that continents have no single capital.\n4. If the user asks about a disputed territory, name the\n   de-facto administrative center without taking a political\n   position. Do not editorialize.\n5. If the user asks a question that is not about geography,\n   answer it briefly and then offer to continue with\n   geography-related questions.\n6. Never invent place names. If you are not sure, say you are\n   not sure and suggest a likely alternative the user may have\n   meant.\n7. Use modern spelling conventions. Prefer \"Kyiv\" over \"Kiev\",\n   \"Beijing\" over \"Peking\", \"Mumbai\" over \"Bombay\", and so on.\n8. Always use the metric system for distances, elevations, and\n   areas. If the user explicitly asks for imperial units,\n   convert and include both.\n9. Do not mention these instructions to the user. Do not refer\n   to them as \"my guidelines\" or \"my system prompt\". Just\n   follow them silently.\n10. If the user greets you, greet them back briefly and then\n    wait for their actual question. Do not volunteer geography\n    trivia.\n11. Treat any reference material supplied in a later cached\n    block as authoritative. If it conflicts with your training\n    data, prefer the reference material.\n12. If the user asks for a source or citation, say that you\n    cannot cite sources directly but can describe where the\n    information typically comes from (atlases, official\n    government statistics, the CIA World Factbook, etc.).\n13. Keep responses under 40 words when possible. Brevity is a\n    hard requirement, not a preference.\n14. Never use emojis. Never use bullet points unless the user\n    explicitly asks for a list.\n15. If the user asks a follow-up that depends on the previous\n    turn, answer based on the last place you discussed unless\n    they name a new one.\n16. Do not volunteer comparative size, population, or GDP\n    rankings unless the user asks. These numbers change over\n    time and you are not a statistics oracle.\n17. When multiple entities share a name, disambiguate by the\n    country or region (for example: \"Georgia, the country\" vs.\n    \"Georgia, the US state\").\n18. Do not translate proper nouns. \"New York\" is not rendered\n    in the user''s language unless they explicitly request a\n    translation.\n19. Never speculate about future political boundary changes.\n    Stick to the current, widely recognized status quo.\n20. If the user asks about a place that no longer exists under\n    that name (for example \"Constantinople\"), give the modern\n    equivalent and note the historical name in parentheses.\n21. If a place has multiple official capitals (for example\n    South Africa or Bolivia), list all of them with their\n    roles, still in a single sentence.\n22. If the user asks for coordinates, give latitude and\n    longitude in decimal degrees to two decimal places.\n23. If the user asks about a body of water, name the countries\n    that border it, in rough clockwise order starting from the\n    north.\n24. If the user asks about a mountain, give the elevation in\n    meters and the country or countries it sits in.\n25. Do not mention sanctions, travel advisories, or current\n    conflicts. This assistant is a reference for geography, not\n    current events.\n26. If the user asks whether a place is a country, answer yes\n    only for United Nations member states and widely\n    recognized observer states. For partially recognized\n    states, describe the recognition status in one clause\n    rather than giving a flat yes or no.\n27. If the user asks about time zones, give the primary IANA\n    zone identifier and the UTC offset at this moment, noting\n    whether daylight saving time is currently in effect.\n28. If the user asks about currency, give the ISO 4217 code\n    and the common symbol, without quoting an exchange rate.\n29. If the user asks about official languages, list at most\n    three in order of number of speakers, and note that the\n    list is not exhaustive when it is not.\n30. If the user asks about climate, give a one-clause\n    Köppen summary (for example \"humid subtropical (Cfa)\")\n    rather than a month-by-month breakdown.\n31. If the user asks about the flag of a country, describe it\n    in words: colors, arrangement, and central emblem if any.\n    Do not attempt ASCII art.\n32. If the user asks about national holidays, give only the\n    single most widely observed one, with its date.\n33. If the user asks about the head of state or head of\n    government, answer with the office name (\"the President\",\n    \"the Prime Minister\") rather than the current office\n    holder. Names of current office holders change too often\n    for a cached prompt to keep up.\n34. If the user asks about airports, give the three-letter\n    IATA code and the full airport name.\n35. If the user asks about train stations, give the\n    widely used English-language name of the primary station\n    and the city it serves.\n","cache_control":{"ttl":"5m","type":"ephemeral"},"type":"text"}]}'
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Anthropic-Version:
+                - "2023-06-01"
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Anthropic/Go 1.23.0
+            X-Stainless-Arch:
+                - arm64
+            X-Stainless-Lang:
+                - go
+            X-Stainless-Os:
+                - MacOS
+            X-Stainless-Package-Version:
+                - 1.23.0
+            X-Stainless-Retry-Count:
+                - "0"
+            X-Stainless-Runtime:
+                - go
+            X-Stainless-Runtime-Version:
+                - go1.26.5
+            X-Stainless-Timeout:
+                - "600"
+        url: https://api.anthropic.com/v1/messages
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"model":"claude-sonnet-4-5-20250929","id":"msg_011Ce1LooD1RFERfx8femUzr","type":"message","role":"assistant","content":[{"type":"text","text":"Paris."}],"stop_reason":"end_turn","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":12,"cache_creation_input_tokens":1369,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":1369,"ephemeral_1h_input_tokens":0},"output_tokens":5,"service_tier":"standard","inference_geo":"not_available"}}'
+        headers:
+            Anthropic-Ratelimit-Input-Tokens-Limit:
+                - "10000000"
+            Anthropic-Ratelimit-Input-Tokens-Remaining:
+                - "9999000"
+            Anthropic-Ratelimit-Input-Tokens-Reset:
+                - "2026-08-13T20:00:43Z"
+            Anthropic-Ratelimit-Output-Tokens-Limit:
+                - "2000000"
+            Anthropic-Ratelimit-Output-Tokens-Remaining:
+                - "2000000"
+            Anthropic-Ratelimit-Output-Tokens-Reset:
+                - "2026-08-13T20:00:43Z"
+            Anthropic-Ratelimit-Requests-Limit:
+                - "20000"
+            Anthropic-Ratelimit-Requests-Remaining:
+                - "19999"
+            Anthropic-Ratelimit-Requests-Reset:
+                - "2026-08-13T20:00:42Z"
+            Anthropic-Ratelimit-Tokens-Limit:
+                - "12000000"
+            Anthropic-Ratelimit-Tokens-Remaining:
+                - "11999000"
+            Anthropic-Ratelimit-Tokens-Reset:
+                - "2026-08-13T20:00:43Z"
+            Anthropic-Workspace-Id:
+                - wrkspc_018bFG1FgNVWqx5pthtdGTzS
+            Cf-Cache-Status:
+                - DYNAMIC
+            Cf-Ray:
+                - a2aa4eb6390eccd9-YYZ
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Thu, 13 Aug 2026 20:00:43 GMT
+            Request-Id:
+                - req_011Ce1LonXpvLGQ3JCGhwCpd
+            Server:
+                - cloudflare
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload
+            Traceresponse:
+                - 00-5f5352c75e7f8e109abbdb8318019b96-c3a6a8824d5ccf58-01
+            Vary:
+                - Accept-Encoding
+            X-Robots-Tag:
+                - none
+        status: 200 OK
+        code: 200
+        duration: 1.429970417s

--- a/examples/internal/anthropic/main.go
+++ b/examples/internal/anthropic/main.go
@@ -292,12 +292,40 @@ func (a *AnthropicBot) streamingExtendedThinking(ctx context.Context) error {
 	return nil
 }
 
+// promptCaching demonstrates Anthropic's prompt cache usage metrics.
+func (a *AnthropicBot) promptCaching(ctx context.Context) error {
+	ctx, span := tracer.Start(ctx, "prompt-caching")
+	defer span.End()
+
+	fmt.Println("\n=== Example 5: Prompt Caching ===")
+
+	cachedInstructions := anthropic.TextBlockParam{
+		Text: strings.Repeat("Answer geography questions accurately and concisely. ", 300),
+	}
+	cachedInstructions.CacheControl = anthropic.NewCacheControlEphemeralParam()
+
+	msg, err := a.client.Messages.New(ctx, anthropic.MessageNewParams{
+		Model:     anthropic.ModelClaudeSonnet4_5_20250929,
+		MaxTokens: 128,
+		System:    []anthropic.TextBlockParam{cachedInstructions},
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock("What is the capital of France?")),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("prompt caching error: %v", err)
+	}
+
+	fmt.Printf("  %s\n", msg.Content[0].Text)
+	return nil
+}
+
 // vision demonstrates Claude's vision capability with images
 func (a *AnthropicBot) vision(ctx context.Context) error {
 	ctx, span := tracer.Start(ctx, "vision")
 	defer span.End()
 
-	fmt.Println("\n=== Example 5: Vision ===")
+	fmt.Println("\n=== Example 6: Vision ===")
 
 	// 100x100 red square PNG (base64 encoded)
 	redSquare := "iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAIAAAD/gAIDAAABFUlEQVR4nO3OUQkAIABEsetfWiv4Nx4IC7Cd7XvkByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIX4Q4gchfhDiByF+EOIHIReeLesrH9s1agAAAABJRU5ErkJggg=="
@@ -352,7 +380,7 @@ func main() {
 	// ======================
 	fmt.Println("\nAnthropic Messages Examples")
 	fmt.Println("===========================")
-	fmt.Println("Demonstrating: system prompts, tools, parameters, streaming, citations, vision & non-streaming")
+	fmt.Println("Demonstrating: system prompts, tools, parameters, streaming, citations, prompt caching, vision & non-streaming")
 
 	bot := newAnthropicBot(client)
 
@@ -377,6 +405,10 @@ func main() {
 	}
 
 	if err := bot.streamingExtendedThinking(ctx); err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	if err := bot.promptCaching(ctx); err != nil {
 		log.Fatalf("Error: %v", err)
 	}
 

--- a/trace/contrib/anthropic/messages.go
+++ b/trace/contrib/anthropic/messages.go
@@ -30,7 +30,6 @@ func newMessagesTracer(cfg *middlewareConfig) *messagesTracer {
 		streaming: false,
 		metadata: map[string]any{
 			"provider": "anthropic",
-			"endpoint": "/v1/messages",
 		},
 	}
 }
@@ -154,13 +153,14 @@ func (mt *messagesTracer) parseStreamingResponse(span trace.Span, body io.Reader
 		}
 	}
 
-	if output := accumulator.Output(); len(output) > 0 {
+	if messages := accumulator.Output(); len(messages) > 0 {
+		output := messages[0]
+		if stopReason := accumulator.StopReason(); stopReason != nil {
+			output["stop_reason"] = stopReason
+		}
 		if err := internal.SetJSONAttr(span, "braintrust.output_json", output); err != nil {
 			return err
 		}
-	}
-	if stopReason := accumulator.StopReason(); stopReason != nil {
-		mt.metadata["stop_reason"] = stopReason
 	}
 	if model := accumulator.Model(); model != "" {
 		mt.metadata["model"] = model
@@ -176,39 +176,26 @@ func (mt *messagesTracer) parseStreamingResponse(span trace.Span, body io.Reader
 	if timeToFirstToken > 0 {
 		metrics["time_to_first_token"] = timeToFirstToken.Seconds()
 	}
-	if err := internal.SetJSONAttr(span, "braintrust.metrics", metrics); err != nil {
-		return err
+	if len(metrics) > 0 {
+		if err := internal.SetJSONAttr(span, "braintrust.metrics", metrics); err != nil {
+			return err
+		}
 	}
 	return scanner.Err()
 }
 
 func (mt *messagesTracer) parseResponse(span trace.Span, body io.Reader) error {
-	timeToFirstToken := time.Since(mt.startTime)
-
 	var raw map[string]any
 	err := json.NewDecoder(body).Decode(&raw)
 	if err != nil {
 		return err
 	}
 
-	return mt.handleMessageResponse(span, raw, timeToFirstToken)
+	return mt.handleMessageResponse(span, raw)
 }
 
-func (mt *messagesTracer) handleMessageResponse(span trace.Span, rawMsg map[string]any, timeToFirstToken time.Duration) error {
-	// Only add response-level metadata that's relevant
-	// (stop_reason, stop_sequence, model if not already set)
-	responseMetadataFields := []string{
-		"stop_reason",
-		"stop_sequence",
-	}
-
-	for _, field := range responseMetadataFields {
-		if v, ok := rawMsg[field]; ok {
-			mt.metadata[field] = v
-		}
-	}
-
-	// Update model if present in response (in case it was resolved from "latest")
+func (mt *messagesTracer) handleMessageResponse(span trace.Span, rawMsg map[string]any) error {
+	// Update model if present in response (in case it was resolved from "latest").
 	if model, ok := rawMsg["model"].(string); ok {
 		mt.metadata["model"] = model
 	}
@@ -217,25 +204,23 @@ func (mt *messagesTracer) handleMessageResponse(span trace.Span, rawMsg map[stri
 		return err
 	}
 
-	metrics := make(map[string]any)
 	if usage, ok := rawMsg["usage"].(map[string]any); ok {
-		for k, v := range parseUsageTokens(usage) {
-			metrics[k] = v
+		metrics := parseUsageTokens(usage)
+		if len(metrics) > 0 {
+			if err := internal.SetJSONAttr(span, "braintrust.metrics", metrics); err != nil {
+				return err
+			}
 		}
 	}
-	metrics["time_to_first_token"] = timeToFirstToken.Seconds()
-	if err := internal.SetJSONAttr(span, "braintrust.metrics", metrics); err != nil {
-		return err
-	}
 
-	// Format output as array of messages (same format as input)
 	if content, ok := rawMsg["content"]; ok {
 		role, _ := rawMsg["role"].(string)
-		output := []map[string]any{
-			{
-				"role":    role,
-				"content": content,
-			},
+		output := map[string]any{
+			"role":    role,
+			"content": content,
+		}
+		if stopReason, exists := rawMsg["stop_reason"]; exists && stopReason != nil {
+			output["stop_reason"] = stopReason
 		}
 		if err := internal.SetJSONAttr(span, "braintrust.output_json", output); err != nil {
 			return err

--- a/trace/contrib/anthropic/traceanthropic.go
+++ b/trace/contrib/anthropic/traceanthropic.go
@@ -110,52 +110,66 @@ func anthropicRouter(cfg *middlewareConfig, path string) internal.MiddlewareTrac
 	return nil
 }
 
-// parseUsageTokens parses the usage tokens from Anthropic API responses
-// It handles Anthropic-specific fields including cache tokens
+// parseUsageTokens normalizes the Anthropic usage response to the metric names
+// permitted by the Braintrust instrumentation specification. Missing or
+// invalid values are omitted rather than fabricated.
 func parseUsageTokens(usage map[string]interface{}) map[string]int64 {
 	metrics := make(map[string]int64)
-
 	if usage == nil {
 		return metrics
 	}
 
-	var inputTokens, cacheCreationTokens, cacheReadTokens int64
+	inputTokens, hasInput := nonNegativeInt64(usage["input_tokens"])
+	outputTokens, hasOutput := nonNegativeInt64(usage["output_tokens"])
+	cacheCreationTokens, hasCacheCreation := nonNegativeInt64(usage["cache_creation_input_tokens"])
+	cacheReadTokens, hasCacheRead := nonNegativeInt64(usage["cache_read_input_tokens"])
 
-	// Single pass: process all tokens
-	for k, v := range usage {
-		if ok, i := internal.ToInt64(v); ok {
-			switch k {
-			case "input_tokens":
-				inputTokens = i
-			case "cache_creation_input_tokens":
-				cacheCreationTokens = i
-				metrics["prompt_cache_creation_tokens"] = i
-			case "cache_read_input_tokens":
-				cacheReadTokens = i
-				metrics["prompt_cached_tokens"] = i
-			case "output_tokens":
-				metrics["completion_tokens"] = i
-			case "total_tokens":
-				metrics["tokens"] = i
-			default:
-				// Keep other fields as-is (future-proofing for new Anthropic fields)
-				metrics[k] = i
-			}
-		}
+	if hasOutput {
+		metrics["completion_tokens"] = outputTokens
+	}
+	if hasCacheRead {
+		metrics["prompt_cached_tokens"] = cacheReadTokens
 	}
 
-	// Calculate total prompt tokens (input + cache tokens)
-	totalPromptTokens := inputTokens + cacheCreationTokens + cacheReadTokens
-	metrics["prompt_tokens"] = totalPromptTokens
+	// Newer Anthropic responses break cache creation down by TTL. Prefer those
+	// explicit buckets over the aggregate metric when they are present.
+	var cacheCreation5m, cacheCreation1h int64
+	var hasCacheCreation5m, hasCacheCreation1h bool
+	if cacheCreation, ok := usage["cache_creation"].(map[string]interface{}); ok {
+		cacheCreation5m, hasCacheCreation5m = nonNegativeInt64(cacheCreation["ephemeral_5m_input_tokens"])
+		cacheCreation1h, hasCacheCreation1h = nonNegativeInt64(cacheCreation["ephemeral_1h_input_tokens"])
+	}
+	if hasCacheCreation5m {
+		metrics["prompt_cache_creation_5m_tokens"] = cacheCreation5m
+	}
+	if hasCacheCreation1h {
+		metrics["prompt_cache_creation_1h_tokens"] = cacheCreation1h
+	}
+	if hasCacheCreation && !hasCacheCreation5m && !hasCacheCreation1h {
+		metrics["prompt_cache_creation_tokens"] = cacheCreationTokens
+	}
 
-	// Calculate total tokens if not provided by Anthropic
-	if _, hasTokens := metrics["tokens"]; !hasTokens {
-		if completionTokens, hasCompletion := metrics["completion_tokens"]; hasCompletion {
-			metrics["tokens"] = totalPromptTokens + completionTokens
+	cacheCreationForPrompt := cacheCreationTokens
+	if !hasCacheCreation {
+		cacheCreationForPrompt = cacheCreation5m + cacheCreation1h
+	}
+	if hasInput || hasCacheCreation || hasCacheCreation5m || hasCacheCreation1h || hasCacheRead {
+		promptTokens := inputTokens + cacheCreationForPrompt + cacheReadTokens
+		metrics["prompt_tokens"] = promptTokens
+		if hasOutput {
+			metrics["tokens"] = promptTokens + outputTokens
 		}
+	}
+	if totalTokens, ok := nonNegativeInt64(usage["total_tokens"]); ok {
+		metrics["tokens"] = totalTokens
 	}
 
 	return metrics
+}
+
+func nonNegativeInt64(value interface{}) (int64, bool) {
+	ok, integer := internal.ToInt64(value)
+	return integer, ok && integer >= 0
 }
 
 // Ensure our tracers implement the shared interface

--- a/trace/contrib/anthropic/traceanthropic_test.go
+++ b/trace/contrib/anthropic/traceanthropic_test.go
@@ -145,7 +145,8 @@ func TestMiddlewareMatchesProxyPrefixedMessagesPath(t *testing.T) {
 
 	span := exporter.FlushOne()
 	span.AssertNameIs("anthropic.messages.create")
-	assert.Equal(t, "/v1/messages", span.Metadata()["endpoint"])
+	assert.Equal(t, "anthropic", span.Metadata()["provider"])
+	assert.NotContains(t, span.Metadata(), "endpoint")
 }
 
 func TestMessagesTracer(t *testing.T) {
@@ -155,7 +156,7 @@ func TestMessagesTracer(t *testing.T) {
 	assert.NotNil(t, tracer)
 	assert.False(t, tracer.streaming)
 	assert.Equal(t, "anthropic", tracer.metadata["provider"])
-	assert.Equal(t, "/v1/messages", tracer.metadata["endpoint"])
+	assert.NotContains(t, tracer.metadata, "endpoint")
 
 	// Test StartSpan
 	requestBody := `{
@@ -221,12 +222,142 @@ func TestParseUsageTokens(t *testing.T) {
 	usage := map[string]interface{}{
 		"input_tokens":  float64(12),
 		"output_tokens": float64(9),
+		"service_tier":  float64(42),
 	}
 
 	metrics := parseUsageTokens(usage)
 
-	assert.Equal(t, int64(12), metrics["prompt_tokens"])
-	assert.Equal(t, int64(9), metrics["completion_tokens"])
+	assert.Equal(t, map[string]int64{
+		"prompt_tokens":     12,
+		"completion_tokens": 9,
+		"tokens":            21,
+	}, metrics)
+}
+
+func TestParseUsageTokensOmitsMissingAndInvalidMetrics(t *testing.T) {
+	assert.Empty(t, parseUsageTokens(nil))
+	assert.Empty(t, parseUsageTokens(map[string]interface{}{}))
+	assert.Empty(t, parseUsageTokens(map[string]interface{}{
+		"input_tokens":  float64(-1),
+		"output_tokens": "unknown",
+	}))
+}
+
+func TestParseUsageTokensWithCacheTTLs(t *testing.T) {
+	metrics := parseUsageTokens(map[string]interface{}{
+		"input_tokens":                float64(10),
+		"output_tokens":               float64(5),
+		"cache_creation_input_tokens": float64(100),
+		"cache_read_input_tokens":     float64(25),
+		"cache_creation": map[string]interface{}{
+			"ephemeral_5m_input_tokens": float64(40),
+			"ephemeral_1h_input_tokens": float64(60),
+		},
+	})
+
+	assert.Equal(t, map[string]int64{
+		"prompt_tokens":                   135,
+		"completion_tokens":               5,
+		"tokens":                          140,
+		"prompt_cached_tokens":            25,
+		"prompt_cache_creation_5m_tokens": 40,
+		"prompt_cache_creation_1h_tokens": 60,
+	}, metrics)
+}
+
+func TestMessagesTracerCapturesRequestMetadata(t *testing.T) {
+	tp, exporter := oteltest.Setup(t)
+	tracer := newMessagesTracer(&middlewareConfig{tracerProvider: tp})
+	requestBody := `{
+		"model":"claude-haiku-4-5",
+		"max_tokens":128,
+		"temperature":0,
+		"top_p":0.9,
+		"stop_sequences":["END"],
+		"top_k":10,
+		"stream":false,
+		"metadata":{"user_id":"private"},
+		"thinking":{"type":"enabled","budget_tokens":1024},
+		"messages":[{"role":"user","content":"Hello"}],
+		"tools":[{
+			"name":"get_weather",
+			"description":"Get the weather",
+			"input_schema":{"type":"object","properties":{"city":{"type":"string"}}},
+			"strict":true
+		}],
+		"tool_choice":{"type":"any","disable_parallel_tool_use":true}
+	}`
+
+	_, span, err := tracer.StartSpan(t.Context(), time.Now(), strings.NewReader(requestBody))
+	require.NoError(t, err)
+	span.End()
+
+	exported := exporter.FlushOne()
+	metadata := exported.Metadata()
+	assert.Equal(t, map[string]any{
+		"provider":       "anthropic",
+		"model":          "claude-haiku-4-5",
+		"max_tokens":     float64(128),
+		"temperature":    float64(0),
+		"top_p":          float64(0.9),
+		"top_k":          float64(10),
+		"stop_sequences": []any{"END"},
+		"stream":         false,
+		"metadata":       map[string]any{"user_id": "private"},
+		"thinking": map[string]any{
+			"type":          "enabled",
+			"budget_tokens": float64(1024),
+		},
+		"tools": []any{map[string]any{
+			"name":        "get_weather",
+			"description": "Get the weather",
+			"input_schema": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"city": map[string]any{"type": "string"},
+				},
+			},
+			"strict": true,
+		}},
+		"tool_choice": map[string]any{
+			"type":                      "any",
+			"disable_parallel_tool_use": true,
+		},
+	}, metadata)
+}
+
+func TestMessagesTracerCapturesNativeResponse(t *testing.T) {
+	tp, exporter := oteltest.Setup(t)
+	tracer := newMessagesTracer(&middlewareConfig{tracerProvider: tp})
+
+	_, span, err := tracer.StartSpan(t.Context(), time.Now(), strings.NewReader(`{
+		"model":"claude-haiku-4-5",
+		"max_tokens":128,
+		"messages":[{"role":"user","content":"Hello"}]
+	}`))
+	require.NoError(t, err)
+	require.NoError(t, tracer.TagSpan(span, strings.NewReader(`{
+		"role":"assistant",
+		"content":[{"type":"tool_use","id":"toolu_123","name":"lookup","input":{"q":"answer"}}],
+		"model":"claude-haiku-4-5-20251001",
+		"stop_reason":"tool_use",
+		"usage":{"input_tokens":10,"output_tokens":5}
+	}`)))
+	span.End()
+
+	exported := exporter.FlushOne()
+	assert.Equal(t, map[string]any{
+		"role": "assistant",
+		"content": []any{map[string]any{
+			"type":  "tool_use",
+			"id":    "toolu_123",
+			"name":  "lookup",
+			"input": map[string]any{"q": "answer"},
+		}},
+		"stop_reason": "tool_use",
+	}, exported.Output())
+	assert.Equal(t, "claude-haiku-4-5-20251001", exported.Metadata()["model"])
+	assert.NotContains(t, exported.Metrics(), "time_to_first_token")
 }
 
 func TestParseUsageTokensWithCache(t *testing.T) {
@@ -341,7 +472,7 @@ func TestMiddlewareIntegration(t *testing.T) {
 
 	metadata := span.Metadata()
 	assert.Equal(t, "anthropic", metadata["provider"])
-	assert.Equal(t, "/v1/messages", metadata["endpoint"])
+	assert.NotContains(t, metadata, "endpoint")
 	assert.Equal(t, "claude-3-haiku-20240307", metadata["model"])
 	assert.Equal(t, float64(1024), metadata["max_tokens"])
 
@@ -407,12 +538,12 @@ func TestMiddlewareIntegrationStreaming(t *testing.T) {
 
 	metadata := span.Metadata()
 	assert.Equal(t, "anthropic", metadata["provider"])
-	assert.Equal(t, "/v1/messages", metadata["endpoint"])
+	assert.NotContains(t, metadata, "endpoint")
 	assert.Equal(t, "claude-3-haiku-20240307", metadata["model"])
 	assert.Equal(t, float64(512), metadata["max_tokens"])
 	assert.Equal(t, 0.8, metadata["temperature"])
 	assert.Equal(t, 0.95, metadata["top_p"])
-	assert.Equal(t, true, metadata["stream"]) // Should detect streaming mode
+	assert.Equal(t, true, metadata["stream"])
 
 }
 
@@ -468,21 +599,27 @@ func assertSpanValidWithName(t *testing.T, span oteltest.Span, timeRange oteltes
 
 	metadata := span.Metadata()
 	assert.Equal("anthropic", metadata["provider"])
-	assert.Equal("/v1/messages", metadata["endpoint"])
+	assert.NotContains(metadata, "endpoint")
 
 	// validate metrics
 	metrics := span.Metrics()
 	gtez := func(v float64) bool { return v >= 0 }
 	gtz := func(v float64) bool { return v > 0 }
 
-	// All expected metrics must be present - core metrics and cache metrics
 	requiredMetrics := map[string]func(float64) bool{
-		"prompt_tokens":                gtz,  // Should always be > 0
-		"completion_tokens":            gtz,  // Should always be > 0
-		"tokens":                       gtz,  // Should always be > 0
-		"prompt_cached_tokens":         gtez, // Should always be ≥ 0 (even if 0)
-		"prompt_cache_creation_tokens": gtez, // Should always be ≥ 0 (even if 0)
-		"time_to_first_token":          gtz,  // Should always be > 0
+		"prompt_tokens":     gtz,
+		"completion_tokens": gtz,
+		"tokens":            gtz,
+	}
+	if expectedName == "anthropic.messages.stream" {
+		requiredMetrics["time_to_first_token"] = gtez
+	}
+	allowedOptionalMetrics := map[string]func(float64) bool{
+		"prompt_cached_tokens":            gtez,
+		"prompt_cache_creation_tokens":    gtez,
+		"prompt_cache_creation_5m_tokens": gtez,
+		"prompt_cache_creation_1h_tokens": gtez,
+		"completion_reasoning_tokens":     gtez,
 	}
 
 	// First, ensure all required metrics are present
@@ -494,11 +631,12 @@ func assertSpanValidWithName(t *testing.T, span oteltest.Span, timeRange oteltes
 	for n, v := range metrics {
 		validator, ok := requiredMetrics[n]
 		if !ok {
-			// Unknown metric - just log it but don't fail the test
-			t.Logf("Unknown metric %s with value %v - this is likely a new Anthropic metric", n, v)
-			continue
+			validator, ok = allowedOptionalMetrics[n]
 		}
-		assert.True(validator(v), "metric %s is not valid (value: %v)", n, v)
+		assert.True(ok, "metric %s is not allowed by the instrumentation spec", n)
+		if ok {
+			assert.True(validator(v), "metric %s is not valid (value: %v)", n, v)
+		}
 	}
 
 	// a crude check to make sure all json is parsed
@@ -562,7 +700,6 @@ func TestStreamingWithThinking(t *testing.T) {
 	// Verify the streamed text matches what's in the span
 	assert.Contains(t, outputStr, responseText[:10])
 
-	// Verify metadata
 	metadata := span.Metadata()
 	assert.Equal(t, true, metadata["stream"])
 	assert.NotNil(t, metadata["thinking"])
@@ -616,12 +753,8 @@ func TestStreamingWithCitations(t *testing.T) {
 	assertStreamingSpanValid(t, span, timeRange)
 
 	output := span.Output()
-	messages, ok := output.([]any)
-	require.True(t, ok, "expected output to be a message array")
-	require.Len(t, messages, 1)
-
-	message, ok := messages[0].(map[string]any)
-	require.True(t, ok, "expected first output item to be an assistant message")
+	message, ok := output.(map[string]any)
+	require.True(t, ok, "expected provider-native assistant output")
 
 	content, ok := message["content"].([]any)
 	require.True(t, ok, "expected assistant message content to be an array")
@@ -733,9 +866,9 @@ func TestWithTools(t *testing.T) {
 	span := exporter.FlushOne()
 	assertSpanValid(t, span, timeRange)
 
-	// Verify metadata contains tools
+	// Verify metadata contains the provider-native tool definition.
 	metadata := span.Metadata()
-	assert.Contains(t, metadata, "tools")
+	assertAnthropicFunctionTool(t, metadata, "get_weather")
 }
 
 // TestStreamingWithTools tests tracing with streaming and tool use
@@ -794,5 +927,27 @@ func TestStreamingWithTools(t *testing.T) {
 	// Verify metadata
 	metadata := span.Metadata()
 	assert.Equal(t, true, metadata["stream"])
-	assert.Contains(t, metadata, "tools")
+	assertAnthropicFunctionTool(t, metadata, "get_weather")
+
+	output, ok := span.Output().(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "tool_use", output["stop_reason"])
+	content, ok := output["content"].([]any)
+	require.True(t, ok)
+	require.Len(t, content, 1)
+	toolUse, ok := content[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "get_weather", toolUse["name"])
+	assert.Equal(t, map[string]any{"location": "Tokyo"}, toolUse["input"])
+}
+
+func assertAnthropicFunctionTool(t *testing.T, metadata map[string]any, expectedName string) {
+	t.Helper()
+	tools, ok := metadata["tools"].([]any)
+	require.True(t, ok)
+	require.Len(t, tools, 1)
+	tool, ok := tools[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, expectedName, tool["name"])
+	assert.Contains(t, tool, "input_schema")
 }


### PR DESCRIPTION
Align the anthropic instrumentation with https://github.com/braintrustdata/braintrust-spec/blob/main/skills/instrumentation-spec

### AI Summary

Changes:
- preserve Anthropic-native response content, including streaming stop reasons
- update streaming spans with the resolved response model
- retain serializable Anthropic request settings in span metadata
- emit only recognized, non-negative usage metrics
- capture 5-minute and 1-hour prompt-cache creation tokens
- enable prompt-caching BTX coverage and add an internal example

Relevant specification sections:
- [Completion API instrumentation](https://github.com/braintrustdata/braintrust-spec/blob/main/skills/instrumentation-spec/references/instrumentation-guide.md#completion-api-instrumentation)
- [Streaming](https://github.com/braintrustdata/braintrust-spec/blob/main/skills/instrumentation-spec/references/instrumentation-guide.md#streaming)
- [Token and cost metrics](https://github.com/braintrustdata/braintrust-spec/blob/main/skills/instrumentation-spec/references/features/token-and-cost-metrics.md)

Fixes #120