### PR TITLE
fix(trace): align Bedrock Runtime instrumentation with spec

### DIFF
--- a/btx/btx_test.go
+++ b/btx/btx_test.go
@@ -25,10 +25,6 @@ var skipSpecs = map[string]string{
 	// tracked by the Go SDK's Anthropic instrumentation.
 	"anthropic/prompt_caching_5m": "prompt caching metrics not yet supported",
 	"anthropic/prompt_caching_1h": "prompt caching metrics not yet supported",
-	// Bedrock attachment format: the Go SDK puts the braintrust_attachment
-	// reference under source (Anthropic-style), but the spec expects it under
-	// image.source.bytes (Bedrock-native nesting).
-	"bedrock/attachments": "attachment nesting format differs from spec",
 }
 
 // specRoot is set by TestMain after fetching specs.

--- a/btx/spec_executor.go
+++ b/btx/spec_executor.go
@@ -700,23 +700,45 @@ func buildBedrockContentBlock(raw any) brtypes.ContentBlock {
 	// Image block: {image: {format: "png", source: {bytes: "<base64>"}}}
 	if img, ok := m["image"].(map[string]any); ok {
 		format := stringFromMap(img, "format")
-		if src, ok := img["source"].(map[string]any); ok {
-			if b64, ok := src["bytes"].(string); ok {
-				data, err := base64.StdEncoding.DecodeString(b64)
-				if err != nil {
-					return nil
-				}
-				return &brtypes.ContentBlockMemberImage{
-					Value: brtypes.ImageBlock{
-						Format: brtypes.ImageFormat(format),
-						Source: &brtypes.ImageSourceMemberBytes{Value: data},
-					},
-				}
+		if data, ok := bedrockBlockBytes(img); ok {
+			return &brtypes.ContentBlockMemberImage{
+				Value: brtypes.ImageBlock{
+					Format: brtypes.ImageFormat(format),
+					Source: &brtypes.ImageSourceMemberBytes{Value: data},
+				},
+			}
+		}
+	}
+
+	// Document block: {document: {format: "pdf", name: "blank", source: {bytes: "..."}}}
+	if doc, ok := m["document"].(map[string]any); ok {
+		format := stringFromMap(doc, "format")
+		name := stringFromMap(doc, "name")
+		if data, ok := bedrockBlockBytes(doc); ok {
+			return &brtypes.ContentBlockMemberDocument{
+				Value: brtypes.DocumentBlock{
+					Format: brtypes.DocumentFormat(format),
+					Name:   &name,
+					Source: &brtypes.DocumentSourceMemberBytes{Value: data},
+				},
 			}
 		}
 	}
 
 	return nil
+}
+
+func bedrockBlockBytes(block map[string]any) ([]byte, bool) {
+	source, ok := block["source"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	encoded, ok := source["bytes"].(string)
+	if !ok {
+		return nil, false
+	}
+	data, err := base64.StdEncoding.DecodeString(encoded)
+	return data, err == nil
 }
 
 // --- Google/Gemini executor ---

--- a/examples/internal/bedrockruntime/main.go
+++ b/examples/internal/bedrockruntime/main.go
@@ -419,6 +419,46 @@ func (b *BedrockBot) invokeModelClaude(ctx context.Context) error {
 	return nil
 }
 
+// invokeModelClaudeStream demonstrates stream accumulation and TTFT capture
+// for the low-level Claude InvokeModelWithResponseStream API.
+func (b *BedrockBot) invokeModelClaudeStream(ctx context.Context) error {
+	ctx, span := tracer.Start(ctx, "invoke-model-claude-stream")
+	defer span.End()
+
+	fmt.Println("\n=== Example 7: InvokeModelWithResponseStream (Claude) ===")
+
+	body, err := json.Marshal(map[string]any{
+		"anthropic_version": "bedrock-2023-05-31",
+		"max_tokens":        100,
+		"messages": []any{map[string]any{
+			"role":    "user",
+			"content": []any{map[string]any{"type": "text", "text": "Count to three."}},
+		}},
+	})
+	if err != nil {
+		return fmt.Errorf("invoke-model-stream marshal: %w", err)
+	}
+	out, err := b.client.InvokeModelWithResponseStream(ctx, &bedrockruntime.InvokeModelWithResponseStreamInput{
+		ModelId:     aws.String(haikuModelID),
+		Body:        body,
+		ContentType: aws.String("application/json"),
+		Accept:      aws.String("application/json"),
+	})
+	if err != nil {
+		return fmt.Errorf("invoke-model-stream: %w", err)
+	}
+	defer out.GetStream().Close() //nolint:errcheck
+	for event := range out.GetStream().Events() {
+		if chunk, ok := event.(*types.ResponseStreamMemberChunk); ok {
+			fmt.Printf("  %s\n", truncate(string(chunk.Value.Bytes), 200))
+		}
+	}
+	if err := out.GetStream().Err(); err != nil {
+		return fmt.Errorf("invoke-model-stream events: %w", err)
+	}
+	return nil
+}
+
 // firstText extracts the first text block from a Converse output.
 func firstText(out types.ConverseOutput) string {
 	m, ok := out.(*types.ConverseOutputMemberMessage)
@@ -507,6 +547,7 @@ func main() {
 		{"streaming-extended-thinking", bot.streamingExtendedThinking},
 		{"vision", bot.vision},
 		{"invoke-model-claude", bot.invokeModelClaude},
+		{"invoke-model-claude-stream", bot.invokeModelClaudeStream},
 	}
 	for _, s := range steps {
 		if err := s.fn(ctx); err != nil {

--- a/trace/contrib/anthropic/messages.go
+++ b/trace/contrib/anthropic/messages.go
@@ -132,233 +132,54 @@ func (mt *messagesTracer) TagSpan(span trace.Span, body io.Reader) error {
 
 func (mt *messagesTracer) parseStreamingResponse(span trace.Span, body io.Reader) error {
 	scanner := bufio.NewScanner(body)
-	var allResults []map[string]any
+	accumulator := internal.NewClaudeStreamAccumulator()
 	var timeToFirstToken time.Duration
-	usage := make(map[string]any)
 
 	for scanner.Scan() {
 		line := scanner.Text()
-
 		if !strings.HasPrefix(line, "data: ") {
 			continue
 		}
-
 		line = strings.TrimPrefix(line, "data: ")
 		if line == "[DONE]" {
-			break // End of stream
-		}
-
-		if timeToFirstToken == 0 {
-			timeToFirstToken = time.Since(mt.startTime)
+			break
 		}
 
 		var chunk map[string]any
-		err := json.Unmarshal([]byte(line), &chunk)
-		if err != nil {
+		if err := json.Unmarshal([]byte(line), &chunk); err != nil {
 			return err
 		}
-
-		allResults = append(allResults, chunk)
-
-		// Handle usage in streaming response from different event types
-		eventType, ok := chunk["type"].(string)
-		if ok {
-			switch eventType {
-
-			// Contains input and cache tokens
-			case "message_start":
-				// Usage is nested in message object for message_start events
-				if message, ok := chunk["message"].(map[string]any); ok {
-					if curUsage, ok := message["usage"].(map[string]any); ok {
-						// Initialize combined usage with message_start data (contains input_tokens)
-						for k, v := range curUsage {
-							usage[k] = v
-						}
-					}
-				}
-
-			// Contains output tokens, There can be multiple "message_delta" events in a single response.
-			// But the usage data in there is supposed to be cumulative as per the docs.
-			// So using the last usage data is fine.
-			case "message_delta":
-				// Usage is at top level for message_delta events (contains final output_tokens)
-				if curUsage, ok := chunk["usage"].(map[string]any); ok {
-					// message_delta usage is cumulative, so it overrides any previous values
-					for k, v := range curUsage {
-						usage[k] = v
-					}
-				}
-			}
+		if accumulator.Add(chunk) && timeToFirstToken == 0 {
+			timeToFirstToken = time.Since(mt.startTime)
 		}
 	}
 
-	// Post-process streaming results to match expected output format
-	output := mt.postprocessStreamingResults(allResults)
-	if len(output) > 0 {
+	if output := accumulator.Output(); len(output) > 0 {
 		if err := internal.SetJSONAttr(span, "braintrust.output_json", output); err != nil {
 			return err
 		}
 	}
-
-	// Handle usage metrics
-	metrics := make(map[string]any)
-	if len(usage) > 0 {
-		for k, v := range parseUsageTokens(usage) {
-			metrics[k] = v
-		}
+	if stopReason := accumulator.StopReason(); stopReason != nil {
+		mt.metadata["stop_reason"] = stopReason
 	}
-	metrics["time_to_first_token"] = timeToFirstToken.Seconds()
-	if err := internal.SetJSONAttr(span, "braintrust.metrics", metrics); err != nil {
+	if model := accumulator.Model(); model != "" {
+		mt.metadata["model"] = model
+	}
+	if err := internal.SetJSONAttr(span, "braintrust.metadata", mt.metadata); err != nil {
 		return err
 	}
 
+	metrics := make(map[string]any)
+	for key, value := range parseUsageTokens(accumulator.Usage()) {
+		metrics[key] = value
+	}
+	if timeToFirstToken > 0 {
+		metrics["time_to_first_token"] = timeToFirstToken.Seconds()
+	}
+	if err := internal.SetJSONAttr(span, "braintrust.metrics", metrics); err != nil {
+		return err
+	}
 	return scanner.Err()
-}
-
-func (mt *messagesTracer) postprocessStreamingResults(allResults []map[string]any) []map[string]any {
-	// Track content blocks by index
-	contentBlocks := make(map[int]map[string]any)
-	builders := make(map[int]*strings.Builder)
-	var stopReason interface{}
-
-	for _, result := range allResults {
-		eventType, ok := result["type"].(string)
-		if !ok {
-			continue
-		}
-
-		switch eventType {
-		case "content_block_start":
-			// Initialize a new content block
-			indexf64, ok := result["index"].(float64)
-			if !ok {
-				continue
-			}
-			if contentBlock, ok := result["content_block"].(map[string]any); ok {
-				contentBlocks[int(indexf64)] = contentBlock
-			}
-
-		case "content_block_delta":
-			indexf64, ok := result["index"].(float64)
-			if !ok {
-				continue
-			}
-			idx := int(indexf64)
-
-			if delta, ok := result["delta"].(map[string]any); ok {
-				deltaType, ok := delta["type"].(string)
-				if !ok {
-					continue
-				}
-
-				// Ensure block exists
-				if _, exists := contentBlocks[idx]; !exists {
-					contentBlocks[idx] = make(map[string]any)
-				}
-
-				switch deltaType {
-				case "text_delta":
-					// Accumulate text for text blocks
-					if text, ok := delta["text"].(string); ok {
-						if builders[idx] == nil {
-							builders[idx] = &strings.Builder{}
-						}
-						builders[idx].WriteString(text)
-						contentBlocks[idx]["type"] = "text"
-					}
-				case "input_json_delta":
-					// Accumulate JSON for tool_use blocks
-					if partialJSON, ok := delta["partial_json"].(string); ok {
-						if builders[idx] == nil {
-							builders[idx] = &strings.Builder{}
-						}
-						builders[idx].WriteString(partialJSON)
-						contentBlocks[idx]["type"] = "tool_use"
-					}
-				case "citations_delta":
-					// Accumulate citations for text blocks
-					if citation, ok := delta["citation"].(map[string]any); ok {
-						citations, _ := contentBlocks[idx]["citations"].([]any)
-						contentBlocks[idx]["citations"] = append(citations, citation)
-						contentBlocks[idx]["type"] = "text"
-					}
-				case "thinking_delta":
-					// Accumulate thinking text for extended thinking blocks
-					if thinking, ok := delta["thinking"].(string); ok {
-						if builders[idx] == nil {
-							builders[idx] = &strings.Builder{}
-						}
-						builders[idx].WriteString(thinking)
-						contentBlocks[idx]["type"] = "thinking"
-					}
-				case "signature_delta":
-					// Store signature for extended thinking blocks
-					if sig, ok := delta["signature"].(string); ok {
-						contentBlocks[idx]["signature"] = sig
-					}
-				}
-			}
-
-		case "message_delta":
-			if delta, ok := result["delta"].(map[string]any); ok {
-				if sr, ok := delta["stop_reason"]; ok {
-					stopReason = sr
-				}
-			}
-		}
-	}
-
-	// Convert builders to strings in the appropriate field
-	for idx, builder := range builders {
-		if block, ok := contentBlocks[idx]; ok {
-			msg := builder.String()
-			// Check block type to determine which field to set
-			if blockType, ok := block["type"].(string); ok {
-				switch blockType {
-				case "text":
-					block["text"] = msg
-				case "tool_use":
-					block["input"] = msg
-				case "thinking":
-					block["thinking"] = msg
-				}
-			}
-		}
-	}
-
-	// Store stop reason in metadata if present
-	if stopReason != nil {
-		mt.metadata["stop_reason"] = stopReason
-	}
-
-	// Convert map to sorted content array
-	if len(contentBlocks) == 0 {
-		return nil
-	}
-
-	content := make([]map[string]any, 0, len(contentBlocks))
-	for i := 0; i < len(contentBlocks); i++ {
-		if block, ok := contentBlocks[i]; ok {
-			// Parse accumulated JSON string for tool_use blocks
-			if block["type"] == "tool_use" {
-				if inputStr, ok := block["input"].(string); ok && inputStr != "" {
-					var inputObj any
-					if err := json.Unmarshal([]byte(inputStr), &inputObj); err == nil {
-						block["input"] = inputObj
-					}
-				}
-			}
-			content = append(content, block)
-		}
-	}
-
-	// Format as array of messages (same format as input)
-	return []map[string]any{
-		{
-			"role":    "assistant",
-			"content": content,
-		},
-	}
 }
 
 func (mt *messagesTracer) parseResponse(span trace.Span, body io.Reader) error {

--- a/trace/contrib/bedrockruntime/converse.go
+++ b/trace/contrib/bedrockruntime/converse.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
-	smithydoc "github.com/aws/aws-sdk-go-v2/service/bedrockruntime/document"
+	bedrockdoc "github.com/aws/aws-sdk-go-v2/service/bedrockruntime/document"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
 	"go.opentelemetry.io/otel/trace"
 
@@ -26,28 +26,58 @@ func parseUsageTokens(u *types.TokenUsage) map[string]int64 {
 	}
 
 	var input, cacheRead, cacheWrite int64
-	if u.InputTokens != nil {
+	hasPromptUsage := false
+	if u.InputTokens != nil && *u.InputTokens >= 0 {
 		input = int64(*u.InputTokens)
+		hasPromptUsage = true
 	}
-	if u.OutputTokens != nil {
+	if u.OutputTokens != nil && *u.OutputTokens >= 0 {
 		metrics["completion_tokens"] = int64(*u.OutputTokens)
 	}
-	if u.CacheReadInputTokens != nil {
+	if u.CacheReadInputTokens != nil && *u.CacheReadInputTokens >= 0 {
 		cacheRead = int64(*u.CacheReadInputTokens)
 		metrics["prompt_cached_tokens"] = cacheRead
+		hasPromptUsage = true
 	}
-	if u.CacheWriteInputTokens != nil {
+	if u.CacheWriteInputTokens != nil && *u.CacheWriteInputTokens >= 0 {
 		cacheWrite = int64(*u.CacheWriteInputTokens)
 		metrics["prompt_cache_creation_tokens"] = cacheWrite
+		hasPromptUsage = true
 	}
 
-	promptTotal := input + cacheRead + cacheWrite
-	metrics["prompt_tokens"] = promptTotal
+	var detailedCacheWrite int64
+	hasDetailedCacheWrite := false
+	for _, detail := range u.CacheDetails {
+		if detail.InputTokens == nil || *detail.InputTokens < 0 {
+			continue
+		}
+		value := int64(*detail.InputTokens)
+		detailedCacheWrite += value
+		hasDetailedCacheWrite = true
+		switch detail.Ttl {
+		case types.CacheTTLFiveMinutes:
+			metrics["prompt_cache_creation_5m_tokens"] += value
+		case types.CacheTTLOneHour:
+			metrics["prompt_cache_creation_1h_tokens"] += value
+		}
+	}
+	if hasDetailedCacheWrite {
+		hasPromptUsage = true
+		if u.CacheWriteInputTokens == nil || *u.CacheWriteInputTokens < 0 {
+			cacheWrite = detailedCacheWrite
+			metrics["prompt_cache_creation_tokens"] = cacheWrite
+		}
+	}
 
-	if u.TotalTokens != nil {
+	if hasPromptUsage {
+		promptTotal := input + cacheRead + cacheWrite
+		metrics["prompt_tokens"] = promptTotal
+		if completion, ok := metrics["completion_tokens"]; ok && u.TotalTokens == nil {
+			metrics["tokens"] = promptTotal + completion
+		}
+	}
+	if u.TotalTokens != nil && *u.TotalTokens >= 0 {
 		metrics["tokens"] = int64(*u.TotalTokens)
-	} else if completion, ok := metrics["completion_tokens"]; ok {
-		metrics["tokens"] = promptTotal + completion
 	}
 	return metrics
 }
@@ -72,13 +102,12 @@ func (t *converseTracer) StartSpan(ctx context.Context, start time.Time, in any)
 	}
 
 	setConverseInputAttrs(t.cfg.logger, span, t.metadata, params.ModelId, params.Messages, params.System,
-		params.InferenceConfig, params.ToolConfig, params.AdditionalModelRequestFields, false)
+		params.InferenceConfig, params.ToolConfig, false)
 	return ctx, span
 }
 
-func (t *converseTracer) TagOutput(span trace.Span, out any, start time.Time) {
+func (t *converseTracer) TagOutput(span trace.Span, out any, _ time.Time) {
 	defer span.End()
-	timeToLastByte := time.Since(start).Seconds()
 
 	resp, ok := out.(*bedrockruntime.ConverseOutput)
 	if !ok || resp == nil {
@@ -98,7 +127,6 @@ func (t *converseTracer) TagOutput(span trace.Span, out any, start time.Time) {
 	for k, v := range parseUsageTokens(resp.Usage) {
 		metrics[k] = v
 	}
-	metrics["time_to_first_token"] = timeToLastByte
 	setJSONAttr(t.cfg.logger, span, "braintrust.metrics", metrics)
 }
 
@@ -113,7 +141,6 @@ func setConverseInputAttrs(
 	system []types.SystemContentBlock,
 	infer *types.InferenceConfiguration,
 	toolCfg *types.ToolConfiguration,
-	additional smithydoc.Interface,
 	streaming bool,
 ) {
 	if modelID != nil {
@@ -130,7 +157,7 @@ func setConverseInputAttrs(
 			metadata["top_p"] = *infer.TopP
 		}
 		if len(infer.StopSequences) > 0 {
-			metadata["stop_sequences"] = infer.StopSequences
+			metadata["stop"] = infer.StopSequences
 		}
 	}
 	if toolCfg != nil {
@@ -139,12 +166,6 @@ func setConverseInputAttrs(
 		}
 		if tc := toolChoiceToJSON(toolCfg.ToolChoice); tc != nil {
 			metadata["tool_choice"] = tc
-		}
-	}
-	if additional != nil {
-		var v any
-		if err := additional.UnmarshalSmithyDocument(&v); err == nil && v != nil {
-			metadata["additional_model_request_fields"] = v
 		}
 	}
 	if streaming {
@@ -230,6 +251,10 @@ func contentBlockToJSON(b types.ContentBlock) any {
 		return imageBlockToJSON(v.Value)
 	case *types.ContentBlockMemberDocument:
 		return documentBlockToJSON(v.Value)
+	case *types.ContentBlockMemberAudio:
+		return audioBlockToJSON(v.Value)
+	case *types.ContentBlockMemberVideo:
+		return videoBlockToJSON(v.Value)
 	case *types.ContentBlockMemberReasoningContent:
 		return reasoningBlockToJSON(v.Value)
 	default:
@@ -238,42 +263,77 @@ func contentBlockToJSON(b types.ContentBlock) any {
 }
 
 func imageBlockToJSON(b types.ImageBlock) map[string]any {
-	out := map[string]any{"type": "image", "format": string(b.Format)}
+	image := map[string]any{"format": string(b.Format)}
 	switch src := b.Source.(type) {
 	case *types.ImageSourceMemberBytes:
-		// Emit the Anthropic-style base64 data URL shape so the Braintrust UI
-		// can render the image inline, matching the trace/contrib/anthropic
-		// integration's representation.
-		out["source"] = map[string]any{
-			"type":       "base64",
-			"media_type": "image/" + string(b.Format),
-			"data":       base64.StdEncoding.EncodeToString(src.Value),
-		}
+		image["source"] = map[string]any{"bytes": base64.StdEncoding.EncodeToString(src.Value)}
 	case *types.ImageSourceMemberS3Location:
-		s3 := map[string]any{"type": "s3"}
-		if src.Value.Uri != nil {
-			s3["uri"] = *src.Value.Uri
-		}
-		out["source"] = s3
+		image["source"] = s3SourceToJSON(src.Value)
 	}
-	return out
+	return map[string]any{"type": "image", "image": image}
 }
 
 func documentBlockToJSON(b types.DocumentBlock) map[string]any {
-	out := map[string]any{"type": "document", "format": string(b.Format)}
+	document := map[string]any{"format": string(b.Format)}
 	if b.Name != nil {
-		out["name"] = *b.Name
+		document["name"] = *b.Name
+	}
+	if b.Context != nil {
+		document["context"] = *b.Context
 	}
 	if b.Citations != nil && b.Citations.Enabled != nil {
-		out["citations_enabled"] = *b.Citations.Enabled
+		document["citations_enabled"] = *b.Citations.Enabled
 	}
 	switch src := b.Source.(type) {
 	case *types.DocumentSourceMemberText:
-		out["source"] = map[string]any{"type": "text", "text": src.Value}
+		document["source"] = map[string]any{"text": src.Value}
 	case *types.DocumentSourceMemberBytes:
-		out["source"] = map[string]any{"type": "bytes", "size": len(src.Value)}
+		document["source"] = map[string]any{"bytes": base64.StdEncoding.EncodeToString(src.Value)}
+	case *types.DocumentSourceMemberContent:
+		content := make([]any, 0, len(src.Value))
+		for _, block := range src.Value {
+			if text, ok := block.(*types.DocumentContentBlockMemberText); ok {
+				content = append(content, map[string]any{"text": text.Value})
+			}
+		}
+		document["source"] = map[string]any{"content": content}
+	case *types.DocumentSourceMemberS3Location:
+		document["source"] = s3SourceToJSON(src.Value)
 	}
-	return out
+	return map[string]any{"type": "document", "document": document}
+}
+
+func audioBlockToJSON(b types.AudioBlock) map[string]any {
+	audio := map[string]any{"format": string(b.Format)}
+	switch src := b.Source.(type) {
+	case *types.AudioSourceMemberBytes:
+		audio["source"] = map[string]any{"bytes": base64.StdEncoding.EncodeToString(src.Value)}
+	case *types.AudioSourceMemberS3Location:
+		audio["source"] = s3SourceToJSON(src.Value)
+	}
+	return map[string]any{"type": "audio", "audio": audio}
+}
+
+func videoBlockToJSON(b types.VideoBlock) map[string]any {
+	video := map[string]any{"format": string(b.Format)}
+	switch src := b.Source.(type) {
+	case *types.VideoSourceMemberBytes:
+		video["source"] = map[string]any{"bytes": base64.StdEncoding.EncodeToString(src.Value)}
+	case *types.VideoSourceMemberS3Location:
+		video["source"] = s3SourceToJSON(src.Value)
+	}
+	return map[string]any{"type": "video", "video": video}
+}
+
+func s3SourceToJSON(location types.S3Location) map[string]any {
+	s3 := map[string]any{}
+	if location.Uri != nil {
+		s3["uri"] = *location.Uri
+	}
+	if location.BucketOwner != nil {
+		s3["bucket_owner"] = *location.BucketOwner
+	}
+	return map[string]any{"s3_location": s3}
 }
 
 func reasoningBlockToJSON(b types.ReasoningContentBlock) map[string]any {
@@ -297,11 +357,8 @@ func toolUseBlockToJSON(u types.ToolUseBlock) map[string]any {
 	if u.Name != nil {
 		out["name"] = *u.Name
 	}
-	if u.Input != nil {
-		var v any
-		if err := u.Input.UnmarshalSmithyDocument(&v); err == nil {
-			out["input"] = v
-		}
+	if input, ok := smithyDocumentToJSON(u.Input); ok {
+		out["input"] = input
 	}
 	return out
 }
@@ -320,10 +377,7 @@ func toolResultBlockToJSON(r types.ToolResultBlock) map[string]any {
 		case *types.ToolResultContentBlockMemberText:
 			content = append(content, map[string]any{"type": "text", "text": v.Value})
 		case *types.ToolResultContentBlockMemberJson:
-			var jv any
-			if v.Value != nil {
-				_ = v.Value.UnmarshalSmithyDocument(&jv)
-			}
+			jv, _ := smithyDocumentToJSON(v.Value)
 			content = append(content, map[string]any{"type": "json", "json": jv})
 		default:
 			content = append(content, fallbackMarshal(c))
@@ -348,56 +402,82 @@ func fallbackMarshal(v any) any {
 	return out
 }
 
-// toolsToJSON flattens a list of Tools into JSON-ready maps.
+// toolsToJSON normalizes function tools to the OpenAI tool-definition shape.
+// Bedrock system tools remain provider-native because they are not functions.
 func toolsToJSON(tools []types.Tool) []any {
 	if len(tools) == 0 {
 		return nil
 	}
 	out := make([]any, 0, len(tools))
-	for _, t := range tools {
-		switch v := t.(type) {
+	for _, tool := range tools {
+		switch v := tool.(type) {
 		case *types.ToolMemberToolSpec:
-			spec := map[string]any{}
+			function := map[string]any{}
 			if v.Value.Name != nil {
-				spec["name"] = *v.Value.Name
+				function["name"] = *v.Value.Name
 			}
 			if v.Value.Description != nil {
-				spec["description"] = *v.Value.Description
+				function["description"] = *v.Value.Description
 			}
-			if v.Value.InputSchema != nil {
-				if js, ok := v.Value.InputSchema.(*types.ToolInputSchemaMemberJson); ok && js.Value != nil {
-					var schema any
-					if err := js.Value.UnmarshalSmithyDocument(&schema); err == nil {
-						spec["input_schema"] = schema
-					}
+			if v.Value.Strict != nil {
+				function["strict"] = *v.Value.Strict
+			}
+			if schema, ok := v.Value.InputSchema.(*types.ToolInputSchemaMemberJson); ok {
+				if parameters, ok := smithyDocumentToJSON(schema.Value); ok {
+					function["parameters"] = parameters
 				}
 			}
-			out = append(out, map[string]any{"tool_spec": spec})
-		default:
-			out = append(out, fallbackMarshal(t))
+			out = append(out, map[string]any{"type": "function", "function": function})
+		case *types.ToolMemberSystemTool:
+			systemTool := map[string]any{"type": "system"}
+			if v.Value.Name != nil {
+				systemTool["name"] = *v.Value.Name
+			}
+			out = append(out, systemTool)
+		case *types.ToolMemberCachePoint:
+			cachePoint := map[string]any{"type": "cache_point", "cache_type": string(v.Value.Type)}
+			if v.Value.Ttl != "" {
+				cachePoint["ttl"] = string(v.Value.Ttl)
+			}
+			out = append(out, cachePoint)
 		}
 	}
 	return out
 }
 
 func toolChoiceToJSON(tc types.ToolChoice) any {
-	if tc == nil {
-		return nil
-	}
 	switch v := tc.(type) {
 	case *types.ToolChoiceMemberAuto:
-		return map[string]any{"type": "auto"}
+		return "auto"
 	case *types.ToolChoiceMemberAny:
-		return map[string]any{"type": "any"}
+		return "required"
 	case *types.ToolChoiceMemberTool:
-		out := map[string]any{"type": "tool"}
+		function := map[string]any{}
 		if v.Value.Name != nil {
-			out["name"] = *v.Value.Name
+			function["name"] = *v.Value.Name
 		}
-		return out
+		return map[string]any{"type": "function", "function": function}
 	default:
-		return fallbackMarshal(tc)
+		return nil
 	}
+}
+
+func smithyDocumentToJSON(document bedrockdoc.Interface) (any, bool) {
+	// Request documents created by document.NewLazyDocument are marshalers.
+	// Marshal first so their original value is available before AWS sends it;
+	// UnmarshalSmithyDocument is primarily reliable for response documents.
+	if document == nil {
+		return nil, false
+	}
+	data, err := document.MarshalSmithyDocument()
+	if err != nil {
+		return nil, false
+	}
+	var value any
+	if err := json.Unmarshal(data, &value); err != nil {
+		return nil, false
+	}
+	return value, true
 }
 
 // extractOutputMessage returns a JSON-friendly message map from a ConverseOutput union.

--- a/trace/contrib/bedrockruntime/invokemodel.go
+++ b/trace/contrib/bedrockruntime/invokemodel.go
@@ -4,21 +4,23 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
-	"go.opentelemetry.io/otel/attribute"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/braintrustdata/braintrust-sdk-go/logger"
 	"github.com/braintrustdata/braintrust-sdk-go/trace/internal"
 )
 
 // invokeModelTracer handles the non-streaming InvokeModel operation.
 //
-// InvokeModel bodies are model-specific JSON; this tracer captures them
-// best-effort as input_json / output_json. Token normalization runs only for
-// Anthropic Claude models; other providers (Titan, Llama, Cohere) still get
-// input/output logging but no metrics.
+// InvokeModel bodies are model-specific JSON. Anthropic Claude message bodies
+// are normalized into allowlisted input, output, metadata, and metrics fields.
+// Unknown provider-defined schemas are intentionally not copied wholesale.
 type invokeModelTracer struct {
 	cfg      *middlewareConfig
 	metadata map[string]any
@@ -41,30 +43,34 @@ func (t *invokeModelTracer) StartSpan(ctx context.Context, start time.Time, in a
 		t.modelID = *params.ModelId
 		t.metadata["model"] = t.modelID
 	}
-	setAttrBytes(span, "braintrust.input_json", params.Body)
+	if input, ok := normalizeInvokeModelInput(t.modelID, params.Body, t.metadata); ok {
+		setJSONAttr(t.cfg.logger, span, "braintrust.input_json", input)
+	}
 	setJSONAttr(t.cfg.logger, span, "braintrust.metadata", t.metadata)
 	setJSONAttr(t.cfg.logger, span, "braintrust.span_attributes", map[string]string{"type": "llm"})
 	return ctx, span
 }
 
-func (t *invokeModelTracer) TagOutput(span trace.Span, out any, start time.Time) {
+func (t *invokeModelTracer) TagOutput(span trace.Span, out any, _ time.Time) {
 	defer span.End()
-	timeToLast := time.Since(start).Seconds()
 
 	resp, ok := out.(*bedrockruntime.InvokeModelOutput)
 	if !ok || resp == nil {
 		return
 	}
 
-	// Store the raw response JSON directly — no round-trip via decoded-and-
-	// re-marshaled intermediate.
-	setAttrBytes(span, "braintrust.output_json", resp.Body)
-
-	metrics := map[string]any{"time_to_first_token": timeToLast}
-	if usage := extractUsageFromRawBody(t.modelID, resp.Body); usage != nil {
-		for k, v := range usage {
-			metrics[k] = v
+	response := decodeClaudeResponse(t.modelID, resp.Body)
+	if output, resolvedModel, ok := normalizeInvokeModelOutput(response); ok {
+		setJSONAttr(t.cfg.logger, span, "braintrust.output_json", output)
+		if resolvedModel != "" {
+			t.metadata["model"] = resolvedModel
 		}
+	}
+	setJSONAttr(t.cfg.logger, span, "braintrust.metadata", t.metadata)
+
+	metrics := make(map[string]any)
+	for key, value := range extractUsageForModel(t.modelID, response) {
+		metrics[key] = value
 	}
 	setJSONAttr(t.cfg.logger, span, "braintrust.metrics", metrics)
 }
@@ -72,8 +78,8 @@ func (t *invokeModelTracer) TagOutput(span trace.Span, out any, start time.Time)
 // invokeModelStreamTracer handles the streaming variant of InvokeModel.
 //
 // Body chunks arrive as raw JSON bytes in `*types.PayloadPart.Bytes`. We
-// accumulate them as they pass through and best-effort parse the full response
-// at stream end. Only Claude models get token normalization.
+// accumulate them as they pass through and parse Claude responses at stream
+// end. Unknown provider-defined event schemas are not copied wholesale.
 type invokeModelStreamTracer struct {
 	cfg      *middlewareConfig
 	metadata map[string]any
@@ -97,43 +103,280 @@ func (t *invokeModelStreamTracer) StartSpan(ctx context.Context, start time.Time
 		t.modelID = *params.ModelId
 		t.metadata["model"] = t.modelID
 	}
-	setAttrBytes(span, "braintrust.input_json", params.Body)
+	if input, ok := normalizeInvokeModelInput(t.modelID, params.Body, t.metadata); ok {
+		setJSONAttr(t.cfg.logger, span, "braintrust.input_json", input)
+	}
 	setJSONAttr(t.cfg.logger, span, "braintrust.metadata", t.metadata)
 	setJSONAttr(t.cfg.logger, span, "braintrust.span_attributes", map[string]string{"type": "llm"})
 	return ctx, span
 }
 
-func (t *invokeModelStreamTracer) TagOutput(span trace.Span, _ any, start time.Time) {
-	// Stream-wrapping for InvokeModelWithResponseStream isn't implemented yet;
-	// the bidirectional-style reader interface differs from ConverseStream.
-	// Close out the span with a minimal metric so users still see it.
-	defer span.End()
-	metrics := map[string]any{"time_to_first_token": time.Since(start).Seconds()}
-	setJSONAttr(t.cfg.logger, span, "braintrust.metrics", metrics)
-}
-
-// setAttrBytes writes JSON bytes directly onto the span as a string
-// attribute, skipping the decode + re-marshal round-trip that SetJSONAttr
-// would do. Invalid or empty bodies are ignored.
-func setAttrBytes(span trace.Span, key string, body []byte) {
-	if len(body) == 0 || !json.Valid(body) {
+func (t *invokeModelStreamTracer) TagOutput(span trace.Span, out any, start time.Time) {
+	resp, ok := out.(*bedrockruntime.InvokeModelWithResponseStreamOutput)
+	if !ok || resp == nil || resp.GetStream() == nil || resp.GetStream().Reader == nil {
+		span.End()
 		return
 	}
-	span.SetAttributes(attribute.String(key, string(body)))
+	stream := resp.GetStream()
+	observed := &observedInvokeModelStream{
+		log:         t.cfg.logger,
+		inner:       stream.Reader,
+		events:      make(chan types.ResponseStream),
+		done:        make(chan struct{}),
+		span:        span,
+		start:       start,
+		metadata:    t.metadata,
+		modelID:     t.modelID,
+		accumulator: internal.NewClaudeStreamAccumulator(),
+	}
+	stream.Reader = observed
+	go observed.pump()
 }
 
-// extractUsageFromRawBody decodes Claude's Messages-format response usage
-// field into normalized Braintrust metrics. Returns nil for non-Claude models
-// or malformed bodies.
-func extractUsageFromRawBody(modelID string, body []byte) map[string]any {
-	if !strings.Contains(strings.ToLower(modelID), "anthropic.claude") {
+// observedInvokeModelStream keeps the span open until the response stream is
+// drained or closed while transparently forwarding every provider event.
+type observedInvokeModelStream struct {
+	log    logger.Logger
+	inner  bedrockruntime.ResponseStreamReader
+	events chan types.ResponseStream
+	done   chan struct{}
+
+	closeOnce sync.Once
+	finalOnce sync.Once
+
+	span     trace.Span
+	start    time.Time
+	metadata map[string]any
+	modelID  string
+
+	mu           sync.Mutex
+	ttftRecorded bool
+	timeToFirst  time.Duration
+	accumulator  *internal.ClaudeStreamAccumulator
+}
+
+func (o *observedInvokeModelStream) Events() <-chan types.ResponseStream { return o.events }
+
+func (o *observedInvokeModelStream) Close() error {
+	o.closeOnce.Do(func() { close(o.done) })
+	err := o.inner.Close()
+	o.finalize()
+	return err
+}
+
+func (o *observedInvokeModelStream) Err() error { return o.inner.Err() }
+
+func (o *observedInvokeModelStream) pump() {
+	defer close(o.events)
+	defer o.finalize()
+	for event := range o.inner.Events() {
+		o.observe(event)
+		select {
+		case o.events <- event:
+		case <-o.done:
+			return
+		}
+	}
+}
+
+func (o *observedInvokeModelStream) observe(event types.ResponseStream) {
+	chunk, ok := event.(*types.ResponseStreamMemberChunk)
+	if !ok || len(chunk.Value.Bytes) == 0 || !isClaudeModel(o.modelID) {
+		return
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(chunk.Value.Bytes, &decoded); err != nil {
+		return
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.accumulator.Add(decoded) && !o.ttftRecorded {
+		o.ttftRecorded = true
+		o.timeToFirst = time.Since(o.start)
+	}
+}
+
+func (o *observedInvokeModelStream) finalize() {
+	o.finalOnce.Do(func() {
+		o.mu.Lock()
+		defer o.mu.Unlock()
+
+		output := o.accumulator.Output()
+		if len(output) > 0 {
+			output[0]["content"] = normalizeClaudeContent(output[0]["content"])
+			if stopReason := o.accumulator.StopReason(); stopReason != nil {
+				output[0]["stop_reason"] = stopReason
+			}
+			setJSONAttr(o.log, o.span, "braintrust.output_json", output)
+		}
+		if model := o.accumulator.Model(); model != "" {
+			o.metadata["model"] = model
+		}
+		setJSONAttr(o.log, o.span, "braintrust.metadata", o.metadata)
+
+		metrics := make(map[string]any)
+		usage := map[string]any{"usage": o.accumulator.Usage()}
+		if normalized := extractUsageForModel(o.modelID, usage); normalized != nil {
+			for key, value := range normalized {
+				metrics[key] = value
+			}
+		}
+		if o.ttftRecorded {
+			metrics["time_to_first_token"] = o.timeToFirst.Seconds()
+		}
+		setJSONAttr(o.log, o.span, "braintrust.metrics", metrics)
+
+		if err := o.inner.Err(); err != nil {
+			o.span.RecordError(err)
+			o.span.SetStatus(codes.Error, err.Error())
+		}
+		o.span.End()
+	})
+}
+
+// normalizeInvokeModelInput extracts Claude messages as the span input and
+// selects only specification-approved request parameters for metadata.
+func normalizeInvokeModelInput(modelID string, body []byte, metadata map[string]any) (any, bool) {
+	if !isClaudeModel(modelID) {
+		return nil, false
+	}
+	var request map[string]any
+	if err := json.Unmarshal(body, &request); err != nil {
+		return nil, false
+	}
+	messages, ok := request["messages"].([]any)
+	if !ok {
+		return nil, false
+	}
+
+	for _, key := range []string{"temperature", "top_p", "max_tokens"} {
+		if value, exists := request[key]; exists {
+			metadata[key] = value
+		}
+	}
+	if stop, exists := request["stop_sequences"]; exists {
+		metadata["stop"] = stop
+	}
+	if tools := normalizeClaudeTools(request["tools"]); len(tools) > 0 {
+		metadata["tools"] = tools
+	}
+	if choice := normalizeClaudeToolChoice(request["tool_choice"]); choice != nil {
+		metadata["tool_choice"] = choice
+	}
+
+	input := make([]any, 0, len(messages)+1)
+	if system, exists := request["system"]; exists {
+		input = append(input, map[string]any{"role": "system", "content": system})
+	}
+	input = append(input, messages...)
+	return input, true
+}
+
+// normalizeInvokeModelOutput selects the Claude assistant message fields and
+// returns the model resolved by the provider response.
+func normalizeInvokeModelOutput(response map[string]any) (output any, resolvedModel string, ok bool) {
+	if response == nil {
+		return nil, "", false
+	}
+	content, exists := response["content"]
+	if !exists {
+		return nil, "", false
+	}
+	message := map[string]any{"role": "assistant", "content": normalizeClaudeContent(content)}
+	if stopReason, exists := response["stop_reason"]; exists {
+		message["stop_reason"] = stopReason
+	}
+	if model, isString := response["model"].(string); isString {
+		resolvedModel = model
+	}
+	return []any{message}, resolvedModel, true
+}
+
+func normalizeClaudeContent(value any) any {
+	content, ok := value.([]any)
+	if !ok {
+		return value
+	}
+	result := make([]any, 0, len(content))
+	for _, rawBlock := range content {
+		block, ok := rawBlock.(map[string]any)
+		if !ok || block["type"] != "thinking" {
+			result = append(result, rawBlock)
+			continue
+		}
+		reasoning := map[string]any{"type": "reasoning"}
+		if text, exists := block["thinking"]; exists {
+			reasoning["text"] = text
+		}
+		if signature, exists := block["signature"]; exists {
+			reasoning["signature"] = signature
+		}
+		result = append(result, reasoning)
+	}
+	return result
+}
+
+func normalizeClaudeTools(value any) []any {
+	tools, ok := value.([]any)
+	if !ok {
 		return nil
 	}
-	var decoded any
-	if err := json.Unmarshal(body, &decoded); err != nil {
+	result := make([]any, 0, len(tools))
+	for _, rawTool := range tools {
+		tool, ok := rawTool.(map[string]any)
+		if !ok {
+			continue
+		}
+		function := map[string]any{}
+		for _, key := range []string{"name", "description"} {
+			if value, exists := tool[key]; exists {
+				function[key] = value
+			}
+		}
+		if parameters, exists := tool["input_schema"]; exists {
+			function["parameters"] = parameters
+		}
+		if strict, exists := tool["strict"]; exists {
+			function["strict"] = strict
+		}
+		result = append(result, map[string]any{"type": "function", "function": function})
+	}
+	return result
+}
+
+func normalizeClaudeToolChoice(value any) any {
+	choice, ok := value.(map[string]any)
+	if !ok {
 		return nil
 	}
-	return extractUsageForModel(modelID, decoded)
+	switch choice["type"] {
+	case "auto":
+		return "auto"
+	case "any":
+		return "required"
+	case "none":
+		return "none"
+	case "tool":
+		name, _ := choice["name"].(string)
+		return map[string]any{"type": "function", "function": map[string]any{"name": name}}
+	default:
+		return nil
+	}
+}
+
+func isClaudeModel(modelID string) bool {
+	return strings.Contains(strings.ToLower(modelID), "anthropic.claude")
+}
+
+func decodeClaudeResponse(modelID string, body []byte) map[string]any {
+	if !isClaudeModel(modelID) {
+		return nil
+	}
+	var response map[string]any
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil
+	}
+	return response
 }
 
 // extractUsageForModel normalizes token metrics from an already-decoded
@@ -143,7 +386,7 @@ func extractUsageForModel(modelID string, body any) map[string]any {
 	if body == nil {
 		return nil
 	}
-	if !strings.Contains(strings.ToLower(modelID), "anthropic.claude") {
+	if !isClaudeModel(modelID) {
 		return nil
 	}
 	m, ok := body.(map[string]any)
@@ -158,28 +401,42 @@ func extractUsageForModel(modelID string, body any) map[string]any {
 	// Reuse the anthropic-style map-based normalization.
 	metrics := make(map[string]any)
 	var input, cacheRead, cacheCreate int64
+	hasPromptUsage := false
 	for k, v := range usage {
 		ok, i := internal.ToInt64(v)
-		if !ok {
+		if !ok || i < 0 {
 			continue
 		}
 		switch k {
 		case "input_tokens":
 			input = i
+			hasPromptUsage = true
 		case "cache_creation_input_tokens":
 			cacheCreate = i
+			hasPromptUsage = true
 			metrics["prompt_cache_creation_tokens"] = i
 		case "cache_read_input_tokens":
 			cacheRead = i
+			hasPromptUsage = true
 			metrics["prompt_cached_tokens"] = i
 		case "output_tokens":
 			metrics["completion_tokens"] = i
 		}
 	}
-	promptTotal := input + cacheRead + cacheCreate
-	metrics["prompt_tokens"] = promptTotal
-	if completion, ok := metrics["completion_tokens"].(int64); ok {
-		metrics["tokens"] = promptTotal + completion
+	if cacheDetails, ok := usage["cache_creation"].(map[string]any); ok {
+		if ok, value := internal.ToInt64(cacheDetails["ephemeral_5m_input_tokens"]); ok && value >= 0 {
+			metrics["prompt_cache_creation_5m_tokens"] = value
+		}
+		if ok, value := internal.ToInt64(cacheDetails["ephemeral_1h_input_tokens"]); ok && value >= 0 {
+			metrics["prompt_cache_creation_1h_tokens"] = value
+		}
+	}
+	if hasPromptUsage {
+		promptTotal := input + cacheRead + cacheCreate
+		metrics["prompt_tokens"] = promptTotal
+		if completion, ok := metrics["completion_tokens"].(int64); ok {
+			metrics["tokens"] = promptTotal + completion
+		}
 	}
 	return metrics
 }

--- a/trace/contrib/bedrockruntime/stream.go
+++ b/trace/contrib/bedrockruntime/stream.go
@@ -2,12 +2,14 @@ package bedrockruntime
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/braintrustdata/braintrust-sdk-go/logger"
@@ -35,7 +37,7 @@ func (t *converseStreamTracer) StartSpan(ctx context.Context, start time.Time, i
 	}
 
 	setConverseInputAttrs(t.cfg.logger, span, t.metadata, params.ModelId, params.Messages, params.System,
-		params.InferenceConfig, params.ToolConfig, params.AdditionalModelRequestFields, true)
+		params.InferenceConfig, params.ToolConfig, true)
 	return ctx, span
 }
 
@@ -209,9 +211,15 @@ func (o *observedConverseStream) finalize() {
 			case "reasoning":
 				block["text"] = s
 			case "tool_use":
-				// Per Bedrock spec, tool_use delta inputs are raw JSON fragments;
-				// store them as a single string field for now.
-				block["input"] = s
+				// Bedrock sends tool input as JSON fragments. Decode the complete
+				// value so streaming output matches non-streaming output. Preserve
+				// malformed model output verbatim rather than dropping it.
+				var input any
+				if err := json.Unmarshal([]byte(s), &input); err == nil {
+					block["input"] = input
+				} else {
+					block["input"] = s
+				}
 			}
 		}
 
@@ -236,9 +244,15 @@ func (o *observedConverseStream) finalize() {
 		for k, v := range parseUsageTokens(o.usage) {
 			metrics[k] = v
 		}
-		metrics["time_to_first_token"] = o.timeToFirst.Seconds()
+		if o.ttftRecorded {
+			metrics["time_to_first_token"] = o.timeToFirst.Seconds()
+		}
 		setJSONAttr(o.log, o.span, "braintrust.metrics", metrics)
 
+		if err := o.inner.Err(); err != nil {
+			o.span.RecordError(err)
+			o.span.SetStatus(codes.Error, err.Error())
+		}
 		o.span.End()
 	})
 }

--- a/trace/contrib/bedrockruntime/tracebedrockruntime.go
+++ b/trace/contrib/bedrockruntime/tracebedrockruntime.go
@@ -30,8 +30,9 @@
 //
 // Coverage notes:
 //   - Converse and ConverseStream are fully instrumented (input/output/metrics).
-//   - InvokeModel and InvokeModelWithResponseStream capture input/output bodies;
-//     token metrics are normalized only for Anthropic Claude models.
+//   - InvokeModel and InvokeModelWithResponseStream normalize Anthropic Claude
+//     messages, streamed output, and token metrics. Other model-specific body
+//     formats are not captured because their schemas are provider-defined.
 //   - InvokeModelWithBidirectionalStream is not instrumented.
 package bedrockruntime
 

--- a/trace/contrib/bedrockruntime/tracebedrockruntime_test.go
+++ b/trace/contrib/bedrockruntime/tracebedrockruntime_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"image"
 	"image/color"
 	"image/png"
@@ -79,6 +78,34 @@ func TestParseUsageTokens(t *testing.T) {
 		m := parseUsageTokens(u)
 		assert.Equal(t, int64(10), m["tokens"])
 	})
+
+	t.Run("missing usage is omitted rather than fabricated as zero", func(t *testing.T) {
+		m := parseUsageTokens(&types.TokenUsage{OutputTokens: aws.Int32(6)})
+		assert.NotContains(t, m, "prompt_tokens")
+		assert.NotContains(t, m, "tokens")
+		assert.Equal(t, int64(6), m["completion_tokens"])
+	})
+
+	t.Run("cache write TTL details are normalized", func(t *testing.T) {
+		m := parseUsageTokens(&types.TokenUsage{
+			InputTokens: aws.Int32(20),
+			CacheDetails: []types.CacheDetail{
+				{Ttl: types.CacheTTLFiveMinutes, InputTokens: aws.Int32(5)},
+				{Ttl: types.CacheTTLOneHour, InputTokens: aws.Int32(15)},
+			},
+		})
+		assert.Equal(t, int64(5), m["prompt_cache_creation_5m_tokens"])
+		assert.Equal(t, int64(15), m["prompt_cache_creation_1h_tokens"])
+	})
+
+	t.Run("negative provider usage is omitted", func(t *testing.T) {
+		m := parseUsageTokens(&types.TokenUsage{
+			InputTokens:  aws.Int32(-1),
+			OutputTokens: aws.Int32(-2),
+			TotalTokens:  aws.Int32(-3),
+		})
+		assert.Empty(t, m)
+	})
 }
 
 // TestExtractUsageForModel verifies InvokeModel's Claude-only token branch.
@@ -151,7 +178,7 @@ func setUpTest(t *testing.T) (*bedrockruntime.Client, *oteltest.Exporter) {
 }
 
 // assertSpanValid checks the common properties of a Bedrock span.
-func assertSpanValid(t *testing.T, span oteltest.Span, timeRange oteltest.TimeRange, wantName string) {
+func assertSpanValid(t *testing.T, span oteltest.Span, timeRange oteltest.TimeRange, wantName string, streaming bool) {
 	t.Helper()
 	a := assert.New(t)
 
@@ -163,10 +190,15 @@ func assertSpanValid(t *testing.T, span oteltest.Span, timeRange oteltest.TimeRa
 	a.Equal("bedrock", metadata["provider"])
 
 	metrics := span.Metrics()
-	required := []string{"prompt_tokens", "completion_tokens", "tokens", "time_to_first_token"}
+	required := []string{"prompt_tokens", "completion_tokens", "tokens"}
 	for _, m := range required {
 		a.Contains(metrics, m, "missing metric %s", m)
 		a.Greater(metrics[m], float64(0), "metric %s should be > 0", m)
+	}
+	if streaming {
+		a.Greater(metrics["time_to_first_token"], float64(0))
+	} else {
+		a.NotContains(metrics, "time_to_first_token")
 	}
 }
 
@@ -183,8 +215,9 @@ func TestConverse(t *testing.T) {
 			},
 		}},
 		InferenceConfig: &types.InferenceConfiguration{
-			MaxTokens:   aws.Int32(64),
-			Temperature: aws.Float32(0.2),
+			MaxTokens:     aws.Int32(64),
+			Temperature:   aws.Float32(0.2),
+			StopSequences: []string{"DONE"},
 		},
 	})
 	timeRange := timer.Tick()
@@ -196,13 +229,15 @@ func TestConverse(t *testing.T) {
 	require.NotEmpty(t, msg.Value.Content)
 
 	span := exporter.FlushOne()
-	assertSpanValid(t, span, timeRange, "bedrock.converse")
+	assertSpanValid(t, span, timeRange, "bedrock.converse", false)
 
 	metadata := span.Metadata()
 	assert.Equal(t, "converse", metadata["endpoint"])
 	assert.Equal(t, testModelID, metadata["model"])
 	assert.Equal(t, float64(64), metadata["max_tokens"])
 	assert.Equal(t, 0.2, metadata["temperature"])
+	assert.Equal(t, []any{"DONE"}, metadata["stop"])
+	assert.NotContains(t, metadata, "stop_sequences")
 	assert.Equal(t, "end_turn", metadata["stop_reason"])
 
 	input := span.Attr("braintrust.input_json").String()
@@ -253,15 +288,28 @@ func TestConverseWithTools(t *testing.T) {
 	assert.Equal(t, types.StopReasonToolUse, out.StopReason)
 
 	span := exporter.FlushOne()
-	assertSpanValid(t, span, timeRange, "bedrock.converse")
+	assertSpanValid(t, span, timeRange, "bedrock.converse", false)
 
 	metadata := span.Metadata()
 	assert.Equal(t, "tool_use", metadata["stop_reason"])
 	tools, ok := metadata["tools"].([]any)
 	require.True(t, ok, "tools should be a list in metadata")
 	require.Len(t, tools, 1)
-	assert.Contains(t, fmt.Sprint(tools[0]), "get_weather")
-	assert.Equal(t, map[string]any{"type": "auto"}, metadata["tool_choice"])
+	assert.Equal(t, map[string]any{
+		"type": "function",
+		"function": map[string]any{
+			"name":        "get_weather",
+			"description": "Get weather for a city",
+			"parameters": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"city": map[string]any{"type": "string"},
+				},
+				"required": []any{"city"},
+			},
+		},
+	}, tools[0])
+	assert.Equal(t, "auto", metadata["tool_choice"])
 
 	output := span.Attr("braintrust.output_json").String()
 	assert.Contains(t, output, "tool_use")
@@ -303,7 +351,7 @@ func TestConverseStream(t *testing.T) {
 	assert.Contains(t, gotText.String(), "Paris")
 
 	span := exporter.FlushOne()
-	assertSpanValid(t, span, timeRange, "bedrock.converse-stream")
+	assertSpanValid(t, span, timeRange, "bedrock.converse-stream", true)
 
 	metadata := span.Metadata()
 	assert.Equal(t, "converse-stream", metadata["endpoint"])
@@ -341,10 +389,9 @@ func TestConverseWithImage(t *testing.T) {
 	span := exporter.FlushOne()
 	input := span.Attr("braintrust.input_json").String()
 	assert.Contains(t, input, `"type":"image"`)
-	assert.Contains(t, input, `"format":"png"`)
-	assert.Contains(t, input, `"type":"base64"`)
-	assert.Contains(t, input, `"media_type":"image/png"`)
-	assert.Contains(t, input, `"data":"iVBORw0KGgo`)
+	assert.Contains(t, input, `"image":{"format":"png"`)
+	assert.Contains(t, input, `"source":{"bytes":"iVBORw0KGgo`)
+	assert.NotContains(t, input, `"type":"base64"`)
 }
 
 func TestConverseWithDocumentCitations(t *testing.T) {
@@ -416,6 +463,7 @@ func TestConverseReasoningOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	span := exporter.FlushOne()
+	assert.NotContains(t, span.Metadata(), "additional_model_request_fields")
 	output := span.Attr("braintrust.output_json").String()
 	// Claude with thinking enabled returns a reasoningContent block and a text
 	// answer. The model may format 12231 with or without a thousands separator,
@@ -491,20 +539,28 @@ func TestInvokeModelClaude(t *testing.T) {
 	metadata := span.Metadata()
 	assert.Equal(t, "bedrock", metadata["provider"])
 	assert.Equal(t, "invoke_model", metadata["endpoint"])
-	assert.Equal(t, testModelID, metadata["model"])
+	assert.Equal(t, "claude-haiku-4-5-20251001", metadata["model"])
+	assert.Equal(t, float64(50), metadata["max_tokens"])
 
 	input := span.Attr("braintrust.input_json").String()
 	assert.Contains(t, input, "capital of France")
+	assert.NotContains(t, input, "anthropic_version")
+	assert.NotContains(t, input, "max_tokens")
 
 	output := span.Attr("braintrust.output_json").String()
 	assert.Contains(t, output, "Paris")
+	assert.Contains(t, output, `"role":"assistant"`)
+	assert.NotContains(t, output, `"usage"`)
+	assert.NotContains(t, output, `"id"`)
 
 	// Claude token branch fires on any model id starting with anthropic.claude.
 	metrics := span.Metrics()
 	assert.Greater(t, metrics["prompt_tokens"], float64(0))
 	assert.Greater(t, metrics["completion_tokens"], float64(0))
 	assert.Greater(t, metrics["tokens"], float64(0))
-	assert.Greater(t, metrics["time_to_first_token"], float64(0))
+	assert.Equal(t, float64(0), metrics["prompt_cache_creation_5m_tokens"])
+	assert.Equal(t, float64(0), metrics["prompt_cache_creation_1h_tokens"])
+	assert.NotContains(t, metrics, "time_to_first_token")
 }
 
 func TestConverseError(t *testing.T) {

--- a/trace/internal/claudestream.go
+++ b/trace/internal/claudestream.go
@@ -1,0 +1,190 @@
+package internal
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// ClaudeStreamAccumulator incrementally reduces Claude Messages API stream
+// events into one assistant message and merged usage data.
+type ClaudeStreamAccumulator struct {
+	contentBlocks map[int]map[string]any
+	builders      map[int]*strings.Builder
+	usage         map[string]any
+	stopReason    any
+	model         string
+	maxIndex      int
+}
+
+// NewClaudeStreamAccumulator creates an empty Claude stream accumulator.
+func NewClaudeStreamAccumulator() *ClaudeStreamAccumulator {
+	return &ClaudeStreamAccumulator{
+		contentBlocks: make(map[int]map[string]any),
+		builders:      make(map[int]*strings.Builder),
+		usage:         make(map[string]any),
+		maxIndex:      -1,
+	}
+}
+
+// Add consumes one decoded Claude event. It reports whether the event contains
+// generated text, reasoning, or tool-input content suitable for TTFT.
+func (a *ClaudeStreamAccumulator) Add(event map[string]any) bool {
+	eventType, _ := event["type"].(string)
+	switch eventType {
+	case "message_start":
+		if message, ok := event["message"].(map[string]any); ok {
+			if model, ok := message["model"].(string); ok {
+				a.model = model
+			}
+			a.mergeUsage(message["usage"])
+		}
+	case "content_block_start":
+		index, ok := claudeEventIndex(event)
+		if !ok {
+			return false
+		}
+		block, _ := event["content_block"].(map[string]any)
+		a.contentBlocks[index] = cloneClaudeMap(block)
+		a.builders[index] = &strings.Builder{}
+		a.trackIndex(index)
+	case "content_block_delta":
+		return a.addDelta(event)
+	case "message_delta":
+		if delta, ok := event["delta"].(map[string]any); ok {
+			if stopReason, exists := delta["stop_reason"]; exists {
+				a.stopReason = stopReason
+			}
+		}
+		a.mergeUsage(event["usage"])
+	}
+	return false
+}
+
+func (a *ClaudeStreamAccumulator) addDelta(event map[string]any) bool {
+	index, ok := claudeEventIndex(event)
+	if !ok {
+		return false
+	}
+	a.trackIndex(index)
+	block := a.contentBlocks[index]
+	if block == nil {
+		block = make(map[string]any)
+		a.contentBlocks[index] = block
+	}
+	builder := a.builders[index]
+	if builder == nil {
+		builder = &strings.Builder{}
+		a.builders[index] = builder
+	}
+
+	delta, _ := event["delta"].(map[string]any)
+	switch delta["type"] {
+	case "text_delta":
+		text, ok := delta["text"].(string)
+		if !ok {
+			return false
+		}
+		block["type"] = "text"
+		builder.WriteString(text)
+		return text != ""
+	case "input_json_delta":
+		partial, ok := delta["partial_json"].(string)
+		if !ok {
+			return false
+		}
+		block["type"] = "tool_use"
+		builder.WriteString(partial)
+		return partial != ""
+	case "thinking_delta":
+		thinking, ok := delta["thinking"].(string)
+		if !ok {
+			return false
+		}
+		block["type"] = "thinking"
+		builder.WriteString(thinking)
+		return thinking != ""
+	case "signature_delta":
+		if signature, ok := delta["signature"].(string); ok {
+			block["signature"] = signature
+		}
+	case "citations_delta":
+		if citation, ok := delta["citation"].(map[string]any); ok {
+			citations, _ := block["citations"].([]any)
+			block["citations"] = append(citations, citation)
+			block["type"] = "text"
+		}
+	}
+	return false
+}
+
+// Output returns the accumulated assistant message, or nil when no content
+// blocks were observed.
+func (a *ClaudeStreamAccumulator) Output() []map[string]any {
+	if len(a.contentBlocks) == 0 {
+		return nil
+	}
+	content := make([]any, 0, len(a.contentBlocks))
+	for index := 0; index <= a.maxIndex; index++ {
+		block := a.contentBlocks[index]
+		if block == nil {
+			continue
+		}
+		text := ""
+		if builder := a.builders[index]; builder != nil {
+			text = builder.String()
+		}
+		switch block["type"] {
+		case "text":
+			block["text"] = text
+		case "tool_use":
+			var input any
+			if err := json.Unmarshal([]byte(text), &input); err == nil {
+				block["input"] = input
+			} else {
+				block["input"] = text
+			}
+		case "thinking":
+			block["thinking"] = text
+		}
+		content = append(content, block)
+	}
+	return []map[string]any{{"role": "assistant", "content": content}}
+}
+
+// Usage returns the merged usage fields from message_start and message_delta.
+func (a *ClaudeStreamAccumulator) Usage() map[string]any { return a.usage }
+
+// StopReason returns the final provider stop reason, if present.
+func (a *ClaudeStreamAccumulator) StopReason() any { return a.stopReason }
+
+// Model returns the model resolved from message_start, if present.
+func (a *ClaudeStreamAccumulator) Model() string { return a.model }
+
+func (a *ClaudeStreamAccumulator) mergeUsage(value any) {
+	usage, ok := value.(map[string]any)
+	if !ok {
+		return
+	}
+	for key, item := range usage {
+		a.usage[key] = item
+	}
+}
+
+func (a *ClaudeStreamAccumulator) trackIndex(index int) {
+	if index > a.maxIndex {
+		a.maxIndex = index
+	}
+}
+
+func claudeEventIndex(event map[string]any) (int, bool) {
+	ok, value := ToInt64(event["index"])
+	return int(value), ok
+}
+
+func cloneClaudeMap(value map[string]any) map[string]any {
+	result := make(map[string]any, len(value))
+	for key, item := range value {
+		result[key] = item
+	}
+	return result
+}


### PR DESCRIPTION
Align the bedrockruntime instrumentation with https://github.com/braintrustdata/braintrust-spec/blob/main/skills/instrumentation-spec

### AI Summary

Normalize Bedrock Converse attachments, tools, request metadata, and cache metrics to the Braintrust instrumentation contract. Reconstruct Claude InvokeModel streams with complete output, usage, errors, and content-based TTFT while avoiding duplicate response buffering.

Share incremental Claude stream aggregation with the Anthropic integration so streaming spans flush resolved model and stop metadata consistently. Expand existing VCR-backed coverage and enable the Bedrock attachment BTX spec.

Fixes #120
Partially addresses #102; non-Claude InvokeModel metrics remain unsupported.