### PR TITLE
fix(eino): align tracing with instrumentation spec

### DIFF
--- a/examples/internal/cloudwego/eino/main.go
+++ b/examples/internal/cloudwego/eino/main.go
@@ -192,38 +192,48 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// First turn: model decides to call the tool
-	firstResp, err := openaiModel.Generate(ctx, []*schema.Message{
+	// Run the full model → tool → model turn inside an Eino graph. The graph
+	// becomes a parent task span, with each model call and tool execution as a child.
+	agentTurn := compose.InvokableLambda(func(ctx context.Context, messages []*schema.Message) (*schema.Message, error) {
+		firstResp, err := openaiModel.Generate(ctx, messages)
+		if err != nil {
+			return nil, fmt.Errorf("initial model call: %w", err)
+		}
+		if len(firstResp.ToolCalls) == 0 {
+			return firstResp, nil
+		}
+
+		toolResults, err := toolsNode.Invoke(ctx, firstResp)
+		if err != nil {
+			return nil, fmt.Errorf("tool execution: %w", err)
+		}
+		followUp := append(append([]*schema.Message{}, messages...), firstResp)
+		followUp = append(followUp, toolResults...)
+		return openaiModel.Generate(ctx, followUp)
+	})
+
+	agentGraph := compose.NewGraph[[]*schema.Message, *schema.Message]()
+	if err := agentGraph.AddLambdaNode("agent_turn", agentTurn); err != nil {
+		log.Fatal(err)
+	}
+	if err := agentGraph.AddEdge(compose.START, "agent_turn"); err != nil {
+		log.Fatal(err)
+	}
+	if err := agentGraph.AddEdge("agent_turn", compose.END); err != nil {
+		log.Fatal(err)
+	}
+	agent, err := agentGraph.Compile(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	finalResp, err := agent.Invoke(ctx, []*schema.Message{
 		{Role: schema.User, Content: "What is 6 multiplied by 7?"},
 	})
 	if err != nil {
-		log.Fatalf("Tool calling Generate failed: %v", err)
+		log.Fatalf("Agent turn failed: %v", err)
 	}
+	fmt.Printf("Tool call result: %s\n", finalResp.Content)
 	handler.Wait()
-
-	// Second turn: execute tool calls via ToolsNode
-	if len(firstResp.ToolCalls) > 0 {
-		toolResults, err := toolsNode.Invoke(ctx, firstResp)
-		if err != nil {
-			log.Fatalf("ToolsNode Invoke failed: %v", err)
-		}
-		handler.Wait()
-
-		// Third turn: model incorporates tool results
-		messages := []*schema.Message{
-			{Role: schema.User, Content: "What is 6 multiplied by 7?"},
-			firstResp,
-		}
-		messages = append(messages, toolResults...)
-		finalResp, err := openaiModel.Generate(ctx, messages)
-		if err != nil {
-			log.Fatalf("Final Generate failed: %v", err)
-		}
-		fmt.Printf("Tool call result: %s\n", finalResp.Content)
-		handler.Wait()
-	} else {
-		fmt.Printf("Model answered directly: %s\n", firstResp.Content)
-	}
 
 	// Example 6: OpenAI embeddings
 	fmt.Println("\n6. OpenAI embeddings")

--- a/trace/contrib/all/go.sum
+++ b/trace/contrib/all/go.sum
@@ -254,6 +254,8 @@ go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
+go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
 golang.org/x/arch v0.15.0 h1:QtOrQd0bTUnhNVNndMpLHNWrDmYzZ2KDqSrEymqInZw=
 golang.org/x/arch v0.15.0/go.mod h1:JmwW7aLIoRUKgaTzhkiEFxvcEiQGyOg9BMonBJUS7EE=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/trace/contrib/cloudwego/eino/integration_test.go
+++ b/trace/contrib/cloudwego/eino/integration_test.go
@@ -1,14 +1,20 @@
 package eino
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"image"
+	"image/color"
+	"image/png"
 	"io"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
 
 	einoembed "github.com/cloudwego/eino-ext/components/embedding/openai"
 	einoopenai "github.com/cloudwego/eino-ext/components/model/openai"
@@ -27,6 +33,11 @@ const testModel = "gpt-4o-mini"
 
 func setUpTest(t *testing.T) (*einoopenai.ChatModel, *Handler, *oteltest.Exporter) {
 	t.Helper()
+	return setUpTestWithModel(t, testModel)
+}
+
+func setUpTestWithModel(t *testing.T, modelName string) (*einoopenai.ChatModel, *Handler, *oteltest.Exporter) {
+	t.Helper()
 
 	tp, exporter := oteltest.Setup(t)
 
@@ -44,7 +55,7 @@ func setUpTest(t *testing.T) (*einoopenai.ChatModel, *Handler, *oteltest.Exporte
 	handler := NewHandlerWithOptions(HandlerOptions{TracerProvider: tp})
 
 	m, err := einoopenai.NewChatModel(context.Background(), &einoopenai.ChatModelConfig{
-		Model:      testModel,
+		Model:      modelName,
 		APIKey:     apiKey,
 		HTTPClient: httpClient,
 	})
@@ -56,6 +67,7 @@ func setUpTest(t *testing.T) (*einoopenai.ChatModel, *Handler, *oteltest.Exporte
 // ctxWithHandler creates a context with the handler registered for ChatModel callbacks.
 func ctxWithHandler(handler *Handler) context.Context {
 	return callbacks.InitCallbacks(context.Background(), &callbacks.RunInfo{
+		Type:      "OpenAI",
 		Component: components.ComponentOfChatModel,
 	}, handler)
 }
@@ -63,40 +75,58 @@ func ctxWithHandler(handler *Handler) context.Context {
 func TestIntegration_NonStreaming(t *testing.T) {
 	m, handler, exporter := setUpTest(t)
 
-	ctx := ctxWithHandler(handler)
-	resp, err := m.Generate(ctx, []*schema.Message{
+	graph := compose.NewGraph[[]*schema.Message, *schema.Message]()
+	require.NoError(t, graph.AddChatModelNode("model", m))
+	require.NoError(t, graph.AddEdge(compose.START, "model"))
+	require.NoError(t, graph.AddEdge("model", compose.END))
+	runner, err := graph.Compile(context.Background())
+	require.NoError(t, err)
+
+	resp, err := runner.Invoke(context.Background(), []*schema.Message{
 		{Role: schema.User, Content: "What is 2+2? Answer with just the number."},
-	})
+	}, compose.WithCallbacks(handler))
 	require.NoError(t, err)
 	handler.Wait()
 
 	assert.Contains(t, resp.Content, "4")
 
 	spans := exporter.Flush()
-	require.Len(t, spans, 1)
-	span := spans[0]
+	require.Len(t, spans, 2)
+	llmSpan, taskSpan := spans[0], spans[1]
+	llmSpan.AssertChildOf(&taskSpan)
+	taskSpan.AssertJSONAttrEquals("braintrust.span_attributes", map[string]any{
+		"name": "Graph",
+		"type": "task",
+	})
 
-	inp := span.Input()
+	inp := llmSpan.Input()
 	require.NotNil(t, inp)
 	inputJSON, _ := json.Marshal(inp)
 	assert.Contains(t, string(inputJSON), "2+2")
 
-	out := span.Output()
-	require.NotNil(t, out)
-	outMap, ok := out.(map[string]any)
+	out := llmSpan.Output()
+	choices, ok := out.([]any)
 	require.True(t, ok)
-	assert.Equal(t, "assistant", outMap["role"])
-	assert.Contains(t, outMap["content"], "4")
+	require.Len(t, choices, 1)
+	choice, ok := choices[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(0), choice["index"])
+	assert.Equal(t, "stop", choice["finish_reason"])
+	message, ok := choice["message"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "assistant", message["role"])
+	assert.Contains(t, message["content"], "4")
 
-	metrics := span.Metrics()
+	metrics := llmSpan.Metrics()
 	require.NotNil(t, metrics)
 	assert.Greater(t, metrics["prompt_tokens"], float64(0))
 	assert.Greater(t, metrics["completion_tokens"], float64(0))
 	assert.Greater(t, metrics["tokens"], float64(0))
 
-	meta := span.Metadata()
+	meta := llmSpan.Metadata()
 	require.NotNil(t, meta)
 	assert.Equal(t, testModel, meta["model"])
+	assert.Equal(t, "openai", meta["provider"])
 }
 
 func TestIntegration_Streaming(t *testing.T) {
@@ -127,10 +157,14 @@ func TestIntegration_Streaming(t *testing.T) {
 	span := spans[0]
 
 	out := span.Output()
-	require.NotNil(t, out)
-	outMap, ok := out.(map[string]any)
+	choices, ok := out.([]any)
 	require.True(t, ok)
-	assert.Equal(t, "assistant", outMap["role"])
+	require.Len(t, choices, 1)
+	choice, ok := choices[0].(map[string]any)
+	require.True(t, ok)
+	message, ok := choice["message"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "assistant", message["role"])
 
 	metrics := span.Metrics()
 	require.NotNil(t, metrics)
@@ -138,12 +172,91 @@ func TestIntegration_Streaming(t *testing.T) {
 	assert.Greater(t, metrics["completion_tokens"], float64(0))
 }
 
-func TestIntegration_ToolCalling(t *testing.T) {
+func TestIntegration_StreamingEarlyClose(t *testing.T) {
 	m, handler, exporter := setUpTest(t)
 
-	ctx := ctxWithHandler(handler)
+	reader, err := m.Stream(ctxWithHandler(handler), []*schema.Message{{
+		Role:    schema.User,
+		Content: "Write twenty words about observability.",
+	}})
+	require.NoError(t, err)
 
-	// Define a tool
+	chunk, err := reader.Recv()
+	require.NoError(t, err)
+	assert.NotEmpty(t, chunk.Content)
+	reader.Close()
+	handler.Wait()
+
+	span := exporter.FlushOne()
+	assert.NotNil(t, span.Output())
+	assert.Greater(t, span.Metrics()["time_to_first_token"], float64(0))
+}
+
+func TestIntegration_Multimodal(t *testing.T) {
+	m, handler, exporter := setUpTest(t)
+	imageData := redPNGBase64(t)
+
+	resp, err := m.Generate(ctxWithHandler(handler), []*schema.Message{{
+		Role: schema.User,
+		UserInputMultiContent: []schema.MessageInputPart{
+			{Type: schema.ChatMessagePartTypeText, Text: "What is the dominant color? Answer with one word."},
+			{
+				Type: schema.ChatMessagePartTypeImageURL,
+				Image: &schema.MessageInputImage{MessagePartCommon: schema.MessagePartCommon{
+					Base64Data: &imageData,
+					MIMEType:   "image/png",
+				}},
+			},
+		},
+	}})
+	require.NoError(t, err)
+	handler.Wait()
+	assert.NotEmpty(t, resp.Content)
+
+	span := exporter.FlushOne()
+	messages, ok := span.Input().([]any)
+	require.True(t, ok)
+	content, ok := messages[0].(map[string]any)["content"].([]any)
+	require.True(t, ok)
+	require.Len(t, content, 2)
+	imagePart := content[1].(map[string]any)
+	imageURL := imagePart["image_url"].(map[string]any)
+	assert.Equal(t, "data:image/png;base64,"+imageData, imageURL["url"])
+	assert.NotNil(t, span.Output())
+}
+
+func TestIntegration_APIError(t *testing.T) {
+	m, handler, exporter := setUpTestWithModel(t, "braintrust-invalid-model")
+
+	_, err := m.Generate(ctxWithHandler(handler), []*schema.Message{{
+		Role:    schema.User,
+		Content: "This request should fail.",
+	}})
+	require.Error(t, err)
+	handler.Wait()
+
+	span := exporter.FlushOne()
+	assert.Equal(t, codes.Error, span.Status().Code)
+	assert.NotEmpty(t, span.Events())
+}
+
+func redPNGBase64(t *testing.T) string {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 64, 64))
+	for y := range 64 {
+		for x := range 64 {
+			img.Set(x, y, color.RGBA{R: 255, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	require.NoError(t, png.Encode(&buf, img))
+	return base64.StdEncoding.EncodeToString(buf.Bytes())
+}
+
+func TestIntegration_ToolCalling(t *testing.T) {
+	m, handler, exporter := setUpTest(t)
+	ctx := context.Background()
+
 	type multiplyInput struct {
 		A float64 `json:"a" jsonschema_description:"First number"`
 		B float64 `json:"b" jsonschema_description:"Second number"`
@@ -159,71 +272,77 @@ func TestIntegration_ToolCalling(t *testing.T) {
 	toolInfo, err := multiplyTool.Info(ctx)
 	require.NoError(t, err)
 	require.NoError(t, m.BindTools([]*schema.ToolInfo{toolInfo}))
-
 	toolsNode, err := compose.NewToolNode(ctx, &compose.ToolsNodeConfig{
 		Tools: []tool.BaseTool{multiplyTool},
 	})
 	require.NoError(t, err)
 
-	// First turn: model decides to call the tool
-	firstResp, err := m.Generate(ctx, []*schema.Message{
-		{Role: schema.User, Content: "What is 6 multiplied by 7? You must use the multiply tool."},
-	})
-	require.NoError(t, err)
-	handler.Wait()
-
-	require.NotEmpty(t, firstResp.ToolCalls, "model should have made a tool call")
-
-	// Verify the LLM span has tool_calls in output
-	llmSpans := exporter.Flush()
-	require.Len(t, llmSpans, 1)
-	llmOut := llmSpans[0].Output()
-	require.NotNil(t, llmOut)
-	llmOutJSON, _ := json.Marshal(llmOut)
-	assert.Contains(t, string(llmOutJSON), "tool_calls")
-	assert.Contains(t, string(llmOutJSON), "multiply")
-
-	// Second turn: execute tool via ToolsNode
-	toolResults, err := toolsNode.Invoke(ctx, firstResp)
-	require.NoError(t, err)
-	handler.Wait()
-
-	// Verify tool span was created
-	toolSpans := exporter.Flush()
-	require.Len(t, toolSpans, 1)
-	toolSpan := toolSpans[0]
-
-	toolOut := toolSpan.Output()
-	require.NotNil(t, toolOut)
-	toolOutMap, ok := toolOut.(map[string]any)
-	require.True(t, ok, "tool output should be parsed JSON, got %T", toolOut)
-	assert.Equal(t, float64(42), toolOutMap["result"])
-
-	// Verify tool span type via raw attribute
-	var spanAttrsStr string
-	for _, a := range toolSpan.Stub.Attributes {
-		if string(a.Key) == "braintrust.span_attributes" {
-			spanAttrsStr = a.Value.AsString()
+	agentTurn := compose.InvokableLambda(func(ctx context.Context, messages []*schema.Message) (*schema.Message, error) {
+		firstResp, err := m.Generate(ctx, messages)
+		if err != nil {
+			return nil, err
 		}
-	}
-	assert.Contains(t, spanAttrsStr, `"type":"tool"`)
+		if len(firstResp.ToolCalls) == 0 {
+			return firstResp, nil
+		}
 
-	// Third turn: model incorporates tool results
-	messages := []*schema.Message{
+		toolResults, err := toolsNode.Invoke(ctx, firstResp)
+		if err != nil {
+			return nil, err
+		}
+		followUp := append(append([]*schema.Message{}, messages...), firstResp)
+		followUp = append(followUp, toolResults...)
+		return m.Generate(ctx, followUp)
+	})
+
+	graph := compose.NewGraph[[]*schema.Message, *schema.Message]()
+	require.NoError(t, graph.AddLambdaNode("agent_turn", agentTurn))
+	require.NoError(t, graph.AddEdge(compose.START, "agent_turn"))
+	require.NoError(t, graph.AddEdge("agent_turn", compose.END))
+	runner, err := graph.Compile(ctx)
+	require.NoError(t, err)
+
+	finalResp, err := runner.Invoke(ctx, []*schema.Message{
 		{Role: schema.User, Content: "What is 6 multiplied by 7? You must use the multiply tool."},
-		firstResp,
-	}
-	messages = append(messages, toolResults...)
-	finalResp, err := m.Generate(ctx, messages)
+	}, compose.WithCallbacks(handler))
 	require.NoError(t, err)
 	handler.Wait()
-
 	assert.Contains(t, finalResp.Content, "42")
 
-	finalSpans := exporter.Flush()
-	require.Len(t, finalSpans, 1)
-	finalMetrics := finalSpans[0].Metrics()
-	require.NotNil(t, finalMetrics)
+	spans := exporter.Flush()
+	require.Len(t, spans, 4)
+	firstLLM, toolSpan, finalLLM, taskSpan := spans[0], spans[1], spans[2], spans[3]
+	firstLLM.AssertChildOf(&taskSpan)
+	toolSpan.AssertChildOf(&taskSpan)
+	finalLLM.AssertChildOf(&taskSpan)
+	taskSpan.AssertJSONAttrEquals("braintrust.span_attributes", map[string]any{
+		"name": "Graph",
+		"type": "task",
+	})
+
+	llmOutJSON, err := json.Marshal(firstLLM.Output())
+	require.NoError(t, err)
+	assert.Contains(t, string(llmOutJSON), `"finish_reason":"tool_calls"`)
+	assert.Contains(t, string(llmOutJSON), "multiply")
+
+	llmMetadata := firstLLM.Metadata()
+	tools, ok := llmMetadata["tools"].([]any)
+	require.True(t, ok)
+	require.Len(t, tools, 1)
+	toolJSON, err := json.Marshal(tools[0])
+	require.NoError(t, err)
+	assert.Contains(t, string(toolJSON), `"name":"multiply"`)
+	assert.Contains(t, string(toolJSON), `"parameters":{"`)
+
+	toolSpan.AssertJSONAttrEquals("braintrust.span_attributes", map[string]any{
+		"name": "multiply",
+		"type": "tool",
+	})
+	toolOutMap, ok := toolSpan.Output().(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(42), toolOutMap["result"])
+
+	finalMetrics := finalLLM.Metrics()
 	assert.Greater(t, finalMetrics["tokens"], float64(0))
 }
 
@@ -260,6 +379,7 @@ func setUpEmbedderTest(t *testing.T) (*einoembed.Embedder, *Handler, *oteltest.E
 // ctxWithEmbedderHandler registers the handler for embedding callbacks.
 func ctxWithEmbedderHandler(handler *Handler) context.Context {
 	return callbacks.InitCallbacks(context.Background(), &callbacks.RunInfo{
+		Type:      "OpenAI",
 		Component: components.ComponentOfEmbedding,
 	}, handler)
 }
@@ -285,17 +405,23 @@ func TestIntegration_EmbedStrings(t *testing.T) {
 	span.AssertJSONAttrEquals("braintrust.span_attributes", map[string]any{"type": "llm"})
 
 	inp := span.Input()
-	arr, ok := inp.([]interface{})
+	inputMap, ok := inp.(map[string]any)
 	require.True(t, ok)
-	require.Len(t, arr, 2)
-	assert.Equal(t, "The quick brown fox jumps over the lazy dog", arr[0])
+	inputs, ok := inputMap["inputs"].([]any)
+	require.True(t, ok)
+	require.Len(t, inputs, 2)
+	firstInput, ok := inputs[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "The quick brown fox jumps over the lazy dog", firstInput["content"])
 
 	out := span.Output()
 	outMap, ok := out.(map[string]interface{})
 	require.True(t, ok)
-	assert.Equal(t, float64(len(vectors[0])), outMap["embedding_length"])
-	assert.Equal(t, float64(2), outMap["embeddings_count"])
+	assert.Equal(t, float64(2), outMap["count"])
+	assert.NotContains(t, outMap, "embedding_length")
 
 	metadata := span.Metadata()
 	assert.Equal(t, "text-embedding-3-small", metadata["model"])
+	assert.Equal(t, "openai", metadata["provider"])
+	assert.NotContains(t, metadata, "encoding_format")
 }

--- a/trace/contrib/cloudwego/eino/testdata/cassettes/TestIntegration_APIError.yaml
+++ b/trace/contrib/cloudwego/eino/testdata/cassettes/TestIntegration_APIError.yaml
@@ -1,0 +1,71 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 103
+        transfer_encoding: []
+        trailer: {}
+        host: api.openai.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"model":"braintrust-invalid-model","messages":[{"role":"user","content":"This request should fail."}]}'
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Content-Type:
+                - application/json
+        url: https://api.openai.com/v1/chat/completions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+                "error": {
+                    "message": "The model `braintrust-invalid-model` does not exist or you do not have access to it.",
+                    "type": "invalid_request_error",
+                    "param": null,
+                    "code": "model_not_found"
+                }
+            }
+        headers:
+            Access-Control-Expose-Headers:
+                - CF-Ray
+                - CF-Ray
+            Alt-Svc:
+                - h3=":443"; ma=86400
+            Cf-Cache-Status:
+                - DYNAMIC
+            Cf-Ray:
+                - a2b29e38cf3d3701-YYZ
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Fri, 14 Aug 2026 20:13:04 GMT
+            Server:
+                - cloudflare
+            Set-Cookie:
+                - __cf_bm=Hxnbuj037Jxoxa0VxUMLlULHRSZxZyQDjcyQ2SyiBGM-1786738384.769396-1.0.1.1-dRcsXKyvjQ9R5TE7LXaaQTXLJ9V3NQYyX4pihrnpodsMS6RX55OHqh7N1Y.HGbRi_IDvD6BGk9izu6_e4F.bf4XLY_Wc5WY3CAWuHk3R6_B2PZAuvar78DG.igmzcnqr; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.openai.com; Expires=Fri, 14 Aug 2026 20:43:04 GMT
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Openai-Proxy-Wasm:
+                - v0.1
+            X-Request-Id:
+                - req_5fb91207bdf04aa3bc38fd442fd41873
+        status: 404 Not Found
+        code: 404
+        duration: 213.726333ms

--- a/trace/contrib/cloudwego/eino/testdata/cassettes/TestIntegration_Multimodal.yaml
+++ b/trace/contrib/cloudwego/eino/testdata/cassettes/TestIntegration_Multimodal.yaml
@@ -1,0 +1,124 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 417
+        transfer_encoding: []
+        trailer: {}
+        host: api.openai.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":[{"type":"text","text":"What is the dominant color? Answer with one word."},{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAZElEQVR4nOzPUQkAIBTAQBH7V9YQfhwPdgm2c9dsWwf8akBrQGtAa0BrQGtAa0BrQGtAa0BrQGtAa0BrQGtAa0BrQGtAa0BrQGtAa0BrQGtAa0BrQGtAa0BrQGtAa0B7AQAA///jRQGCmaQfxwAAAABJRU5ErkJggg=="}}]}]}'
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Content-Type:
+                - application/json
+        url: https://api.openai.com/v1/chat/completions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: |
+            {
+              "id": "chatcmpl-ECsYy7oKgCQ9H3uFjo0cJuczujLMt",
+              "object": "chat.completion",
+              "created": 1786738384,
+              "model": "gpt-4o-mini-2024-07-18",
+              "choices": [
+                {
+                  "index": 0,
+                  "message": {
+                    "role": "assistant",
+                    "content": "Red",
+                    "refusal": null,
+                    "annotations": []
+                  },
+                  "logprobs": null,
+                  "finish_reason": "stop"
+                }
+              ],
+              "usage": {
+                "prompt_tokens": 8518,
+                "completion_tokens": 1,
+                "total_tokens": 8519,
+                "prompt_tokens_details": {
+                  "cached_tokens": 0,
+                  "audio_tokens": 0
+                },
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0,
+                  "audio_tokens": 0,
+                  "accepted_prediction_tokens": 0,
+                  "rejected_prediction_tokens": 0
+                }
+              },
+              "service_tier": "default",
+              "system_fingerprint": "fp_e7eb9f2bc2"
+            }
+        headers:
+            Access-Control-Expose-Headers:
+                - X-Request-ID
+                - CF-Ray
+                - CF-Ray
+            Alt-Svc:
+                - h3=":443"; ma=86400
+            Cf-Cache-Status:
+                - DYNAMIC
+            Cf-Ray:
+                - a2b29e349bfe3701-YYZ
+            Content-Type:
+                - application/json
+            Date:
+                - Fri, 14 Aug 2026 20:13:04 GMT
+            Openai-Organization:
+                - braintrust-data
+            Openai-Processing-Ms:
+                - "470"
+            Openai-Project:
+                - proj_vsCSXafhhByzWOThMrJcZiw9
+            Openai-Version:
+                - "2020-10-01"
+            Server:
+                - cloudflare
+            Set-Cookie:
+                - __cf_bm=4GUPcYUGeydWncaz3rIb0ywDR2akFOW3rkoD3hhXk28-1786738384.0974588-1.0.1.1-djA8ctLd3hA2gwTws4KwVmQwHnSBz20s6A8Xa2tf.B4hioDmJm2iz3paiBGgE.oDOJnkHJdASrFviQvXiqN22Bs8Y_ya1B4iuJik2gCZK4d4Y9fuxf0oAk3cydL7diD1; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.openai.com; Expires=Fri, 14 Aug 2026 20:43:04 GMT
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options:
+                - nosniff
+            X-Openai-Proxy-Wasm:
+                - v0.1
+            X-Ratelimit-Limit-Input-Images:
+                - "50000"
+            X-Ratelimit-Limit-Requests:
+                - "30000"
+            X-Ratelimit-Limit-Tokens:
+                - "150000000"
+            X-Ratelimit-Remaining-Input-Images:
+                - "49999"
+            X-Ratelimit-Remaining-Requests:
+                - "29999"
+            X-Ratelimit-Remaining-Tokens:
+                - "149999220"
+            X-Ratelimit-Reset-Input-Images:
+                - 1ms
+            X-Ratelimit-Reset-Requests:
+                - 2ms
+            X-Ratelimit-Reset-Tokens:
+                - 0s
+            X-Request-Id:
+                - req_f42b19fe8bcd46918469702284595aaa
+        status: 200 OK
+        code: 200
+        duration: 589.231208ms

--- a/trace/contrib/cloudwego/eino/testdata/cassettes/TestIntegration_StreamingEarlyClose.yaml
+++ b/trace/contrib/cloudwego/eino/testdata/cassettes/TestIntegration_StreamingEarlyClose.yaml
@@ -1,0 +1,148 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 158
+        transfer_encoding: []
+        trailer: {}
+        host: api.openai.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write twenty words about observability."}],"stream":true,"stream_options":{"include_usage":true}}'
+        form: {}
+        headers:
+            Accept:
+                - text/event-stream
+            Cache-Control:
+                - no-cache
+            Connection:
+                - keep-alive
+            Content-Type:
+                - application/json
+        url: https://api.openai.com/v1/chat/completions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: |+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"jGRFxkp7Y"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":"Observ"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"w7t6N"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":"ability"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"bpHr"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":" involves"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"QK"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":" monitoring"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":""}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":" systems"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"bDH"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":" to"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"yTziElTp"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":" understand"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":""}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":" their"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"vDmC7"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":" internal"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"H9"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":" state"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Gx3FY"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":" through"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"pJV"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":" metrics"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"jK1"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"aIhn7Pbjxo"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":" logs"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"9Xua57"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"jsFWJWHHVv"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":" traces"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"gVXb"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"wDk1MkVdRI"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":" and"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"yptd7QR"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":" events"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"uQo8"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"jwS39KNkmb"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":" enabling"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"cD"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":" effective"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"C"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":" troubleshooting"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"lgg5o82dfPz"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":" and"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"TJAY6z0"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":" performance"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"a6ZDrdlcXAiX9MG"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":" optimization"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"N8ohRmmUfUfmxH"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"6iZq9zUF7O"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"GlZbd"}
+
+            data: {"id":"chatcmpl-ECsYx2uXn1rpdlcAReKp3Mm3rFBI7","object":"chat.completion.chunk","created":1786738383,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_6339e52f56","choices":[],"usage":{"prompt_tokens":14,"completion_tokens":27,"total_tokens":41,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"oH9baVF4lO"}
+
+            data: [DONE]
+
+        headers:
+            Access-Control-Expose-Headers:
+                - X-Request-ID
+                - CF-Ray
+                - CF-Ray
+            Alt-Svc:
+                - h3=":443"; ma=86400
+            Cf-Cache-Status:
+                - DYNAMIC
+            Cf-Ray:
+                - a2b29e2cfdef3701-YYZ
+            Content-Type:
+                - text/event-stream; charset=utf-8
+            Date:
+                - Fri, 14 Aug 2026 20:13:03 GMT
+            Openai-Organization:
+                - braintrust-data
+            Openai-Processing-Ms:
+                - "247"
+            Openai-Project:
+                - proj_vsCSXafhhByzWOThMrJcZiw9
+            Openai-Version:
+                - "2020-10-01"
+            Server:
+                - cloudflare
+            Set-Cookie:
+                - __cf_bm=YCj20fuciFdSEpuXDpFfh1V.mmX7b7pOF4g94P.3gQ0-1786738382.8775103-1.0.1.1-lnWG_LVzHZoSloIP2NdkmpygysDtKAd889nZi576mQfpx0lzyrpAbr3ffdzhOHCpieTHPPG5k_hHnbeJ8i.HTSrWZOW0T8xjEjfFtdiDz2IUbsAFhdEz5Bmt5Vm1fVg5; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.openai.com; Expires=Fri, 14 Aug 2026 20:43:03 GMT
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options:
+                - nosniff
+            X-Openai-Proxy-Wasm:
+                - v0.1
+            X-Ratelimit-Limit-Requests:
+                - "30000"
+            X-Ratelimit-Limit-Tokens:
+                - "150000000"
+            X-Ratelimit-Remaining-Requests:
+                - "29999"
+            X-Ratelimit-Remaining-Tokens:
+                - "149999987"
+            X-Ratelimit-Reset-Requests:
+                - 2ms
+            X-Ratelimit-Reset-Tokens:
+                - 0s
+            X-Request-Id:
+                - req_f400cdc1cc134bd096d6efa3530efdaa
+        status: 200 OK
+        code: 200
+        duration: 923.745875ms

--- a/trace/contrib/cloudwego/eino/traceeino.go
+++ b/trace/contrib/cloudwego/eino/traceeino.go
@@ -1,8 +1,9 @@
 // Package eino provides OpenTelemetry tracing for CloudWeGo Eino applications.
 //
 // Eino is a Go LLM application framework from CloudWeGo. This package
-// implements the eino callbacks.Handler interface to capture LLM invocations
-// as Braintrust-compatible OpenTelemetry spans.
+// implements the eino callbacks.Handler interface to capture graph runs, LLM
+// and embedding invocations, and tool executions as Braintrust-compatible
+// OpenTelemetry spans.
 //
 // Usage — register the handler globally before any graph executions:
 //
@@ -30,6 +31,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"strings"
 	"sync"
 	"time"
 
@@ -39,9 +41,11 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/cloudwego/eino/callbacks"
+	"github.com/cloudwego/eino/components"
 	"github.com/cloudwego/eino/components/embedding"
 	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/compose"
 	"github.com/cloudwego/eino/schema"
 
 	traceinternal "github.com/braintrustdata/braintrust-sdk-go/trace/internal"
@@ -72,6 +76,14 @@ type HandlerOptions struct {
 	// TracerProvider is an optional custom TracerProvider for testing or custom configurations.
 	// If not provided, the global otel.GetTracerProvider() is used.
 	TracerProvider trace.TracerProvider
+
+	// Provider overrides the provider inferred from callbacks.RunInfo.Type. Set
+	// this for custom model implementations and gateways so pricing is attributed
+	// to the provider that served the request.
+	Provider string
+
+	// Model is used when an Eino callback does not expose a model identifier.
+	Model string
 }
 
 // defaultHandler is the package-level singleton used by orchestrion and DefaultHandler().
@@ -102,22 +114,35 @@ func (h *Handler) tracer() trace.Tracer {
 	return tp.Tracer("braintrust")
 }
 
-// OnStart is called before a component begins processing. It creates a span for
-// ChatModel and Tool components, capturing their inputs.
+// OnStart is called before a component begins processing. It creates spans for
+// graph tasks, chat models, embeddings, and tools, capturing their inputs.
 func (h *Handler) OnStart(ctx context.Context, info *callbacks.RunInfo, input callbacks.CallbackInput) context.Context {
-	if modelInput := model.ConvCallbackInput(input); modelInput != nil {
-		return h.onStartModel(ctx, info, modelInput)
+	// Graph inputs and outputs often have the same concrete types as model inputs
+	// and outputs. Check the component first so an agent run becomes a parent task
+	// rather than an extra LLM span.
+	if isTaskComponent(info) {
+		return h.onStartTask(ctx, info, input)
 	}
-	if toolInput := tool.ConvCallbackInput(input); toolInput != nil {
-		return h.onStartTool(ctx, info, toolInput)
+	if matchesComponent(info, components.ComponentOfChatModel) {
+		if modelInput := model.ConvCallbackInput(input); modelInput != nil {
+			return h.onStartModel(ctx, info, modelInput)
+		}
 	}
-	if embInput := embedding.ConvCallbackInput(input); embInput != nil {
-		return h.onStartEmbedding(ctx, info, embInput)
+	if matchesComponent(info, components.ComponentOfTool) {
+		if toolInput := tool.ConvCallbackInput(input); toolInput != nil {
+			return h.onStartTool(ctx, info, toolInput)
+		}
+	}
+	if matchesComponent(info, components.ComponentOfEmbedding) {
+		if embInput := embedding.ConvCallbackInput(input); embInput != nil {
+			return h.onStartEmbedding(ctx, info, embInput)
+		}
 	}
 	return ctx
 }
 
 func (h *Handler) onStartModel(ctx context.Context, info *callbacks.RunInfo, modelInput *model.CallbackInput) context.Context {
+	startTime := time.Now()
 	spanName := spanNameFromInfo(info)
 	childCtx, span := h.tracer().Start(ctx, spanName, trace.WithSpanKind(trace.SpanKindClient))
 
@@ -125,14 +150,12 @@ func (h *Handler) onStartModel(ctx context.Context, info *callbacks.RunInfo, mod
 		span.RecordError(err)
 	}
 
-	if len(modelInput.Messages) > 0 {
-		msgs := convertMessages(modelInput.Messages)
-		if err := traceinternal.SetJSONAttr(span, "braintrust.input_json", msgs); err != nil {
-			span.RecordError(err)
-		}
+	msgs := convertMessages(modelInput.Messages)
+	if err := traceinternal.SetJSONAttr(span, "braintrust.input_json", msgs); err != nil {
+		span.RecordError(err)
 	}
 
-	metadata := buildMetadata(info, modelInput.Config)
+	metadata := h.buildMetadata(info, modelInput)
 	if err := traceinternal.SetJSONAttr(span, "braintrust.metadata", metadata); err != nil {
 		span.RecordError(err)
 	}
@@ -142,7 +165,7 @@ func (h *Handler) onStartModel(ctx context.Context, info *callbacks.RunInfo, mod
 		span.SetAttributes(attribute.String("gen_ai.request.model", modelInput.Config.Model))
 	}
 
-	childCtx = context.WithValue(childCtx, startTimeKey{}, time.Now())
+	childCtx = context.WithValue(childCtx, startTimeKey{}, startTime)
 	return context.WithValue(childCtx, spanKey{}, span)
 }
 
@@ -150,22 +173,49 @@ func (h *Handler) onStartTool(ctx context.Context, info *callbacks.RunInfo, tool
 	spanName := spanNameFromInfo(info)
 	childCtx, span := h.tracer().Start(ctx, spanName)
 
-	if err := traceinternal.SetJSONAttr(span, "braintrust.span_attributes", map[string]string{"type": "tool"}); err != nil {
+	spanAttrs := map[string]string{
+		"type": "tool",
+		"name": operationNameFromInfo(info),
+	}
+	if err := traceinternal.SetJSONAttr(span, "braintrust.span_attributes", spanAttrs); err != nil {
 		span.RecordError(err)
 	}
 
-	if toolInput.ArgumentsInJSON != "" {
-		// ArgumentsInJSON is already serialized JSON, so set the attribute directly
-		// to avoid double-encoding via SetJSONAttr (which would marshal again).
+	// ArgumentsInJSON is normally serialized JSON. Preserve malformed or plain
+	// string values as JSON strings so braintrust.input_json always remains valid.
+	if json.Valid([]byte(toolInput.ArgumentsInJSON)) {
 		span.SetAttributes(attribute.String("braintrust.input_json", toolInput.ArgumentsInJSON))
+	} else if err := traceinternal.SetJSONAttr(span, "braintrust.input_json", toolInput.ArgumentsInJSON); err != nil {
+		span.RecordError(err)
 	}
 
-	if info != nil && info.Name != "" {
-		if err := traceinternal.SetJSONAttr(span, "braintrust.metadata", map[string]any{"name": info.Name}); err != nil {
+	return context.WithValue(childCtx, spanKey{}, span)
+}
+
+func (h *Handler) onStartTask(ctx context.Context, info *callbacks.RunInfo, input callbacks.CallbackInput) context.Context {
+	startTime := time.Now()
+	spanName := spanNameFromInfo(info)
+	childCtx, span := h.tracer().Start(ctx, spanName)
+
+	spanAttrs := map[string]string{
+		"type": "task",
+		"name": operationNameFromInfo(info),
+	}
+	if err := traceinternal.SetJSONAttr(span, "braintrust.span_attributes", spanAttrs); err != nil {
+		span.RecordError(err)
+	}
+
+	if modelInput := model.ConvCallbackInput(input); modelInput != nil {
+		if err := traceinternal.SetJSONAttr(span, "braintrust.input_json", convertMessages(modelInput.Messages)); err != nil {
+			span.RecordError(err)
+		}
+	} else if input != nil {
+		if err := traceinternal.SetJSONAttr(span, "braintrust.input_json", input); err != nil {
 			span.RecordError(err)
 		}
 	}
 
+	childCtx = context.WithValue(childCtx, startTimeKey{}, startTime)
 	return context.WithValue(childCtx, spanKey{}, span)
 }
 
@@ -178,11 +228,9 @@ func (h *Handler) onStartEmbedding(ctx context.Context, info *callbacks.RunInfo,
 	// as errored would misreport the caller's operation.
 	_ = traceinternal.SetJSONAttr(span, "braintrust.span_attributes", map[string]string{"type": "llm"})
 
-	if len(embInput.Texts) > 0 {
-		_ = traceinternal.SetJSONAttr(span, "braintrust.input_json", embInput.Texts)
-	}
+	_ = traceinternal.SetJSONAttr(span, "braintrust.input_json", embeddingInput(embInput.Texts))
 
-	metadata := buildEmbeddingMetadata(info, embInput.Config)
+	metadata := h.buildEmbeddingMetadata(info, embInput.Config)
 	_ = traceinternal.SetJSONAttr(span, "braintrust.metadata", metadata)
 
 	if embInput.Config != nil && embInput.Config.Model != "" {
@@ -193,13 +241,14 @@ func (h *Handler) onStartEmbedding(ctx context.Context, info *callbacks.RunInfo,
 }
 
 // OnEnd is called after a component returns successfully. It captures output
-// and metrics for ChatModel and Tool components, then ends the span.
+// and metrics for supported components, then ends the span.
 func (h *Handler) OnEnd(ctx context.Context, info *callbacks.RunInfo, output callbacks.CallbackOutput) context.Context {
 	span, ok := ctx.Value(spanKey{}).(trace.Span)
 	if !ok {
 		return ctx
 	}
 	defer span.End()
+	isTask := isTaskComponent(info)
 
 	if modelOutput := model.ConvCallbackOutput(output); modelOutput != nil {
 		if modelOutput.Message != nil {
@@ -207,12 +256,12 @@ func (h *Handler) OnEnd(ctx context.Context, info *callbacks.RunInfo, output cal
 			if err := traceinternal.SetJSONAttr(span, "braintrust.output_json", out); err != nil {
 				span.RecordError(err)
 			}
-			// OTel semantic conventions
-			if modelOutput.Message.ResponseMeta != nil && modelOutput.Message.ResponseMeta.FinishReason != "" {
+			// OTel GenAI conventions apply to the leaf model call, not its task parent.
+			if !isTask && modelOutput.Message.ResponseMeta != nil && modelOutput.Message.ResponseMeta.FinishReason != "" {
 				span.SetAttributes(attribute.String("gen_ai.finish_reason", modelOutput.Message.ResponseMeta.FinishReason))
 			}
 		}
-		if modelOutput.TokenUsage != nil {
+		if !isTask && modelOutput.TokenUsage != nil {
 			metrics := modelTokenUsageToMetrics(modelOutput.TokenUsage)
 			if len(metrics) > 0 {
 				if err := traceinternal.SetJSONAttr(span, "braintrust.metrics", metrics); err != nil {
@@ -224,14 +273,15 @@ func (h *Handler) OnEnd(ctx context.Context, info *callbacks.RunInfo, output cal
 	}
 
 	if toolOutput := tool.ConvCallbackOutput(output); toolOutput != nil {
-		if toolOutput.Response != "" {
-			// Response may be JSON or plain text. If valid JSON, set directly
-			// to avoid double-encoding via SetJSONAttr.
-			if json.Valid([]byte(toolOutput.Response)) {
-				span.SetAttributes(attribute.String("braintrust.output_json", toolOutput.Response))
-			} else if err := traceinternal.SetJSONAttr(span, "braintrust.output_json", toolOutput.Response); err != nil {
+		if toolOutput.ToolOutput != nil {
+			converted, err := convertToolResult(toolOutput.ToolOutput)
+			if err != nil {
+				span.RecordError(err)
+			} else if err := traceinternal.SetJSONAttr(span, "braintrust.output_json", converted); err != nil {
 				span.RecordError(err)
 			}
+		} else if err := setToolResponse(span, toolOutput.Response); err != nil {
+			span.RecordError(err)
 		}
 		return ctx
 	}
@@ -247,6 +297,12 @@ func (h *Handler) OnEnd(ctx context.Context, info *callbacks.RunInfo, output cal
 			}
 		}
 		return ctx
+	}
+
+	if isTask && output != nil {
+		if err := traceinternal.SetJSONAttr(span, "braintrust.output_json", output); err != nil {
+			span.RecordError(err)
+		}
 	}
 
 	return ctx
@@ -273,13 +329,20 @@ func (h *Handler) OnStartWithStreamInput(ctx context.Context, info *callbacks.Ru
 	input *schema.StreamReader[callbacks.CallbackInput]) context.Context {
 	defer input.Close()
 
-	// Consume the stream, keeping the last model/tool input.
+	// Consume the stream, retaining every task input and the last recognized
+	// leaf-component input.
+	isTask := isTaskComponent(info)
+	var taskInputs []callbacks.CallbackInput
 	var lastModelInput *model.CallbackInput
 	var lastToolInput *tool.CallbackInput
+	var lastEmbeddingInput *embedding.CallbackInput
 	for {
 		item, err := input.Recv()
 		if err != nil {
 			break
+		}
+		if isTask {
+			taskInputs = append(taskInputs, item)
 		}
 		if mi := model.ConvCallbackInput(item); mi != nil {
 			lastModelInput = mi
@@ -287,14 +350,23 @@ func (h *Handler) OnStartWithStreamInput(ctx context.Context, info *callbacks.Ru
 		if ti := tool.ConvCallbackInput(item); ti != nil {
 			lastToolInput = ti
 		}
+		if ei := embedding.ConvCallbackInput(item); ei != nil {
+			lastEmbeddingInput = ei
+		}
 	}
 
-	// Dispatch to the same onStart* helpers used by OnStart.
-	if lastModelInput != nil {
+	// Graph inputs may be model-shaped, so component identity takes priority.
+	if len(taskInputs) > 0 {
+		return h.onStartTask(ctx, info, collapseStreamValues(taskInputs))
+	}
+	if matchesComponent(info, components.ComponentOfChatModel) && lastModelInput != nil {
 		return h.onStartModel(ctx, info, lastModelInput)
 	}
-	if lastToolInput != nil {
+	if matchesComponent(info, components.ComponentOfTool) && lastToolInput != nil {
 		return h.onStartTool(ctx, info, lastToolInput)
+	}
+	if matchesComponent(info, components.ComponentOfEmbedding) && lastEmbeddingInput != nil {
+		return h.onStartEmbedding(ctx, info, lastEmbeddingInput)
 	}
 	return ctx
 }
@@ -312,6 +384,7 @@ func (h *Handler) OnEndWithStreamOutput(ctx context.Context, info *callbacks.Run
 	}
 
 	startTime, hasStartTime := ctx.Value(startTimeKey{}).(time.Time)
+	isTask := isTaskComponent(info)
 
 	h.wg.Add(1)
 	go func() {
@@ -320,6 +393,10 @@ func (h *Handler) OnEndWithStreamOutput(ctx context.Context, info *callbacks.Run
 		defer span.End()
 
 		var chunks []*schema.Message
+		var taskOutputs []callbacks.CallbackOutput
+		var toolResponses strings.Builder
+		var toolResultChunks []*schema.ToolResult
+		var sawToolOutput bool
 		var timeToFirstToken time.Duration
 		for {
 			item, err := output.Recv()
@@ -337,10 +414,43 @@ func (h *Handler) OnEndWithStreamOutput(ctx context.Context, info *callbacks.Run
 			mo := model.ConvCallbackOutput(item)
 			if mo != nil && mo.Message != nil {
 				chunks = append(chunks, mo.Message)
+			} else if isTask {
+				taskOutputs = append(taskOutputs, item)
+			}
+			if !isTask {
+				if to := tool.ConvCallbackOutput(item); to != nil {
+					sawToolOutput = true
+					toolResponses.WriteString(to.Response)
+					if to.ToolOutput != nil {
+						toolResultChunks = append(toolResultChunks, to.ToolOutput)
+					}
+				}
 			}
 		}
 
 		if len(chunks) == 0 {
+			if len(taskOutputs) > 0 {
+				if err := traceinternal.SetJSONAttr(span, "braintrust.output_json", collapseStreamValues(taskOutputs)); err != nil {
+					span.RecordError(err)
+				}
+			} else if len(toolResultChunks) > 0 {
+				result, err := schema.ConcatToolResults(toolResultChunks)
+				if err != nil {
+					span.RecordError(err)
+					span.SetStatus(codes.Error, err.Error())
+					return
+				}
+				converted, err := convertToolResult(result)
+				if err != nil {
+					span.RecordError(err)
+				} else if err := traceinternal.SetJSONAttr(span, "braintrust.output_json", converted); err != nil {
+					span.RecordError(err)
+				}
+			} else if sawToolOutput {
+				if err := setToolResponse(span, toolResponses.String()); err != nil {
+					span.RecordError(err)
+				}
+			}
 			return
 		}
 
@@ -360,7 +470,7 @@ func (h *Handler) OnEndWithStreamOutput(ctx context.Context, info *callbacks.Run
 		}
 
 		metrics := make(map[string]float64)
-		if finalMsg.ResponseMeta != nil && finalMsg.ResponseMeta.Usage != nil {
+		if !isTask && finalMsg.ResponseMeta != nil && finalMsg.ResponseMeta.Usage != nil {
 			for k, v := range schemaTokenUsageToMetrics(finalMsg.ResponseMeta.Usage) {
 				metrics[k] = float64(v)
 			}
@@ -393,37 +503,65 @@ func (h *Handler) Needed(_ context.Context, _ *callbacks.RunInfo, timing callbac
 	}
 }
 
-// spanNameFromInfo derives a span name from RunInfo.
-func spanNameFromInfo(info *callbacks.RunInfo) string {
+func collapseStreamValues[T any](values []T) any {
+	if len(values) == 1 {
+		return values[0]
+	}
+	return values
+}
+
+func matchesComponent(info *callbacks.RunInfo, component components.Component) bool {
+	return info == nil || info.Component == "" || info.Component == component
+}
+
+func isTaskComponent(info *callbacks.RunInfo) bool {
+	if info == nil {
+		return false
+	}
+	switch info.Component {
+	case compose.ComponentOfGraph, compose.ComponentOfChain, compose.ComponentOfWorkflow:
+		return true
+	default:
+		return false
+	}
+}
+
+func operationNameFromInfo(info *callbacks.RunInfo) string {
 	if info == nil {
 		return "eino"
 	}
 	if info.Name != "" {
-		return "eino." + info.Name
+		return info.Name
 	}
 	if info.Type != "" {
-		return "eino." + info.Type
+		return info.Type
 	}
 	if string(info.Component) != "" {
-		return "eino." + string(info.Component)
+		return string(info.Component)
 	}
 	return "eino"
 }
 
-// buildMetadata constructs the braintrust.metadata map.
-func buildMetadata(info *callbacks.RunInfo, cfg *model.Config) map[string]any {
+// spanNameFromInfo derives a span name from RunInfo.
+func spanNameFromInfo(info *callbacks.RunInfo) string {
+	name := operationNameFromInfo(info)
+	if name == "eino" {
+		return name
+	}
+	return "eino." + name
+}
+
+// buildMetadata constructs the explicitly allowlisted braintrust.metadata map.
+func (h *Handler) buildMetadata(info *callbacks.RunInfo, input *model.CallbackInput) map[string]any {
 	metadata := map[string]any{
-		"provider": "cloudwego/eino",
+		"provider": h.providerFromInfo(info),
 	}
 
-	if info != nil {
-		// Use the implementation type (e.g. "OpenAI", "Anthropic") as the provider
-		// when available, since it's more specific than the framework name.
-		if info.Type != "" {
-			metadata["provider"] = info.Type
-		}
+	if input == nil {
+		return metadata
 	}
 
+	cfg := input.Config
 	if cfg != nil {
 		if cfg.Model != "" {
 			metadata["model"] = cfg.Model
@@ -431,8 +569,8 @@ func buildMetadata(info *callbacks.RunInfo, cfg *model.Config) map[string]any {
 		if cfg.MaxTokens != 0 {
 			metadata["max_tokens"] = cfg.MaxTokens
 		}
-		// Eino uses plain float64 (not *float64), so we can't distinguish
-		// "not set" from "explicitly set to 0". Accept dropping explicit 0.
+		// Eino uses value fields, so an omitted value cannot be distinguished
+		// from an explicit zero.
 		if cfg.Temperature != 0 {
 			metadata["temperature"] = cfg.Temperature
 		}
@@ -444,7 +582,78 @@ func buildMetadata(info *callbacks.RunInfo, cfg *model.Config) map[string]any {
 		}
 	}
 
+	if _, ok := metadata["model"]; !ok && h.opts.Model != "" {
+		metadata["model"] = h.opts.Model
+	}
+
+	if tools := convertToolDefinitions(input.Tools); len(tools) > 0 {
+		metadata["tools"] = tools
+	}
+	if choice, ok := normalizeToolChoice(input.ToolChoice); ok {
+		metadata["tool_choice"] = choice
+	}
+
 	return metadata
+}
+
+func (h *Handler) providerFromInfo(info *callbacks.RunInfo) string {
+	if h.opts.Provider != "" {
+		return strings.ToLower(h.opts.Provider)
+	}
+	if info == nil || info.Type == "" {
+		return "unknown"
+	}
+
+	provider := strings.ToLower(info.Type)
+	switch provider {
+	case "claude":
+		return "anthropic"
+	case "gemini":
+		return "google"
+	default:
+		return provider
+	}
+}
+
+func convertToolDefinitions(tools []*schema.ToolInfo) []map[string]any {
+	result := make([]map[string]any, 0, len(tools))
+	for _, toolInfo := range tools {
+		if toolInfo == nil || toolInfo.Name == "" {
+			continue
+		}
+
+		function := map[string]any{"name": toolInfo.Name}
+		if toolInfo.Desc != "" {
+			function["description"] = toolInfo.Desc
+		}
+		if toolInfo.ParamsOneOf != nil {
+			params, err := toolInfo.ToJSONSchema()
+			if err == nil && params != nil {
+				function["parameters"] = params
+			}
+		}
+		result = append(result, map[string]any{
+			"type":     "function",
+			"function": function,
+		})
+	}
+	return result
+}
+
+func normalizeToolChoice(choice *schema.ToolChoice) (string, bool) {
+	if choice == nil {
+		return "", false
+	}
+	switch *choice {
+	case schema.ToolChoiceForbidden:
+		return "none", true
+	case schema.ToolChoiceAllowed:
+		return "auto", true
+	case schema.ToolChoiceForced:
+		return "required", true
+	default:
+		return "", false
+	}
 }
 
 // convertMessages converts a slice of schema.Message to the OpenAI-compatible format
@@ -460,16 +669,17 @@ func convertMessages(msgs []*schema.Message) []map[string]any {
 	return result
 }
 
-// convertMessage converts a single schema.Message to a map in OpenAI format.
-// Used for input messages — includes tool_call_id but not finish_reason.
-// See convertMessageToOutput for the output counterpart.
+// convertMessage converts a single schema.Message to an OpenAI chat message.
 func convertMessage(msg *schema.Message) map[string]any {
 	m := map[string]any{
 		"role":    string(msg.Role),
-		"content": msg.Content,
+		"content": messageContent(msg),
 	}
 	if len(msg.ToolCalls) > 0 {
 		m["tool_calls"] = convertToolCalls(msg.ToolCalls)
+		if msg.Content == "" && len(msg.UserInputMultiContent) == 0 && len(msg.AssistantGenMultiContent) == 0 && len(msg.MultiContent) == 0 {
+			m["content"] = nil
+		}
 	}
 	if msg.ToolCallID != "" {
 		m["tool_call_id"] = msg.ToolCallID
@@ -477,21 +687,214 @@ func convertMessage(msg *schema.Message) map[string]any {
 	return m
 }
 
-// convertMessageToOutput converts a response message to a map for braintrust.output_json.
-// Used for output messages — includes finish_reason but not tool_call_id.
-// See convertMessage for the input counterpart.
-func convertMessageToOutput(msg *schema.Message) map[string]any {
-	out := map[string]any{
+// convertMessageToOutput converts a response to canonical OpenAI choices.
+func convertMessageToOutput(msg *schema.Message) []map[string]any {
+	message := map[string]any{
 		"role":    string(msg.Role),
-		"content": msg.Content,
-	}
-	if msg.ResponseMeta != nil && msg.ResponseMeta.FinishReason != "" {
-		out["finish_reason"] = msg.ResponseMeta.FinishReason
+		"content": messageContent(msg),
 	}
 	if len(msg.ToolCalls) > 0 {
-		out["tool_calls"] = convertToolCalls(msg.ToolCalls)
+		message["tool_calls"] = convertToolCalls(msg.ToolCalls)
+		if msg.Content == "" && len(msg.AssistantGenMultiContent) == 0 && len(msg.MultiContent) == 0 {
+			message["content"] = nil
+		}
 	}
-	return out
+
+	finishReason := ""
+	if msg.ResponseMeta != nil {
+		finishReason = msg.ResponseMeta.FinishReason
+	}
+	finishReason = normalizeFinishReason(finishReason, len(msg.ToolCalls) > 0)
+
+	return []map[string]any{{
+		"index":         0,
+		"finish_reason": finishReason,
+		"message":       message,
+	}}
+}
+
+func normalizeFinishReason(reason string, hasToolCalls bool) string {
+	switch strings.ToLower(reason) {
+	case "tool_calls", "tool_use", "function_call":
+		return "tool_calls"
+	case "length", "max_tokens", "max_output_tokens":
+		return "length"
+	case "content_filter", "safety":
+		return "content_filter"
+	case "stop", "end_turn", "stop_sequence", "":
+		if hasToolCalls {
+			return "tool_calls"
+		}
+		return "stop"
+	default:
+		return strings.ToLower(reason)
+	}
+}
+
+func messageContent(msg *schema.Message) any {
+	if len(msg.UserInputMultiContent) > 0 {
+		return convertInputParts(msg.UserInputMultiContent)
+	}
+	if len(msg.AssistantGenMultiContent) > 0 {
+		return convertOutputParts(msg.AssistantGenMultiContent)
+	}
+	if len(msg.MultiContent) > 0 {
+		return convertLegacyParts(msg.MultiContent)
+	}
+	return msg.Content
+}
+
+func convertInputParts(parts []schema.MessageInputPart) []map[string]any {
+	result := make([]map[string]any, 0, len(parts))
+	for _, part := range parts {
+		switch part.Type {
+		case schema.ChatMessagePartTypeText:
+			result = append(result, map[string]any{"type": "text", "text": part.Text})
+		case schema.ChatMessagePartTypeImageURL:
+			if part.Image != nil {
+				imageURL := map[string]any{"url": mediaValue(part.Image.MessagePartCommon)}
+				if part.Image.Detail != "" {
+					imageURL["detail"] = part.Image.Detail
+				}
+				result = append(result, map[string]any{"type": "image_url", "image_url": imageURL})
+			}
+		case schema.ChatMessagePartTypeAudioURL:
+			if part.Audio != nil {
+				result = append(result, fileContentPart("", part.Audio.MessagePartCommon))
+			}
+		case schema.ChatMessagePartTypeVideoURL:
+			if part.Video != nil {
+				result = append(result, fileContentPart("", part.Video.MessagePartCommon))
+			}
+		case schema.ChatMessagePartTypeFileURL:
+			if part.File != nil {
+				result = append(result, fileContentPart(part.File.Name, part.File.MessagePartCommon))
+			}
+		}
+	}
+	return result
+}
+
+func convertOutputParts(parts []schema.MessageOutputPart) []map[string]any {
+	result := make([]map[string]any, 0, len(parts))
+	for _, part := range parts {
+		switch part.Type {
+		case schema.ChatMessagePartTypeText:
+			result = append(result, map[string]any{"type": "text", "text": part.Text})
+		case schema.ChatMessagePartTypeImageURL:
+			if part.Image != nil {
+				result = append(result, map[string]any{
+					"type":      "image_url",
+					"image_url": map[string]any{"url": mediaValue(part.Image.MessagePartCommon)},
+				})
+			}
+		case schema.ChatMessagePartTypeAudioURL:
+			if part.Audio != nil {
+				result = append(result, fileContentPart("", part.Audio.MessagePartCommon))
+			}
+		case schema.ChatMessagePartTypeVideoURL:
+			if part.Video != nil {
+				result = append(result, fileContentPart("", part.Video.MessagePartCommon))
+			}
+		case schema.ChatMessagePartTypeReasoning:
+			if part.Reasoning != nil {
+				reasoning := map[string]any{
+					"type": "reasoning",
+					"text": part.Reasoning.Text,
+				}
+				if part.Reasoning.Signature != "" {
+					reasoning["signature"] = part.Reasoning.Signature
+				}
+				result = append(result, reasoning)
+			}
+		}
+	}
+	return result
+}
+
+// Eino still accepts MultiContent, so preserve legacy inputs in normalized form.
+func convertLegacyParts(parts []schema.ChatMessagePart) []map[string]any { //nolint:staticcheck
+	result := make([]map[string]any, 0, len(parts))
+	for _, part := range parts {
+		switch part.Type {
+		case schema.ChatMessagePartTypeText:
+			result = append(result, map[string]any{"type": "text", "text": part.Text})
+		case schema.ChatMessagePartTypeImageURL:
+			if part.ImageURL != nil {
+				url := part.ImageURL.URL
+				if url == "" {
+					url = part.ImageURL.URI
+				}
+				imageURL := map[string]any{"url": url}
+				if part.ImageURL.Detail != "" {
+					imageURL["detail"] = part.ImageURL.Detail
+				}
+				result = append(result, map[string]any{"type": "image_url", "image_url": imageURL})
+			}
+		case schema.ChatMessagePartTypeAudioURL:
+			if part.AudioURL != nil {
+				result = append(result, legacyFileContentPart("", part.AudioURL.URL, part.AudioURL.URI))
+			}
+		case schema.ChatMessagePartTypeVideoURL:
+			if part.VideoURL != nil {
+				result = append(result, legacyFileContentPart("", part.VideoURL.URL, part.VideoURL.URI))
+			}
+		case schema.ChatMessagePartTypeFileURL:
+			if part.FileURL != nil {
+				result = append(result, legacyFileContentPart(part.FileURL.Name, part.FileURL.URL, part.FileURL.URI))
+			}
+		}
+	}
+	return result
+}
+
+func mediaValue(media schema.MessagePartCommon) string {
+	if media.URL != nil {
+		return *media.URL
+	}
+	if media.Base64Data == nil {
+		return ""
+	}
+	if media.MIMEType == "" {
+		return *media.Base64Data
+	}
+	return "data:" + media.MIMEType + ";base64," + *media.Base64Data
+}
+
+func fileContentPart(filename string, media schema.MessagePartCommon) map[string]any {
+	file := map[string]any{"file_data": mediaValue(media)}
+	if filename != "" {
+		file["filename"] = filename
+	}
+	return map[string]any{"type": "file", "file": file}
+}
+
+func legacyFileContentPart(filename, url, uri string) map[string]any {
+	if url == "" {
+		url = uri
+	}
+	file := map[string]any{"file_data": url}
+	if filename != "" {
+		file["filename"] = filename
+	}
+	return map[string]any{"type": "file", "file": file}
+}
+
+func setToolResponse(span trace.Span, response string) error {
+	if json.Valid([]byte(response)) {
+		// Avoid double-encoding JSON tool responses.
+		span.SetAttributes(attribute.String("braintrust.output_json", response))
+		return nil
+	}
+	return traceinternal.SetJSONAttr(span, "braintrust.output_json", response)
+}
+
+func convertToolResult(result *schema.ToolResult) (map[string]any, error) {
+	parts, err := result.ToMessageInputParts()
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"parts": convertInputParts(parts)}, nil
 }
 
 // convertToolCalls converts a slice of schema.ToolCall to OpenAI-compatible format.
@@ -500,7 +903,7 @@ func convertToolCalls(tcs []schema.ToolCall) []map[string]any {
 	for i, tc := range tcs {
 		result[i] = map[string]any{
 			"id":   tc.ID,
-			"type": tc.Type,
+			"type": "function",
 			"function": map[string]any{
 				"name":      tc.Function.Name,
 				"arguments": tc.Function.Arguments,
@@ -513,15 +916,9 @@ func convertToolCalls(tcs []schema.ToolCall) []map[string]any {
 // modelTokenUsageToMetrics converts model.TokenUsage to the standard Braintrust metrics map.
 func modelTokenUsageToMetrics(u *model.TokenUsage) map[string]int64 {
 	metrics := make(map[string]int64)
-	if u.PromptTokens > 0 {
-		metrics["prompt_tokens"] = int64(u.PromptTokens)
-	}
-	if u.CompletionTokens > 0 {
-		metrics["completion_tokens"] = int64(u.CompletionTokens)
-	}
-	if u.TotalTokens > 0 {
-		metrics["tokens"] = int64(u.TotalTokens)
-	}
+	addNonNegativeMetric(metrics, "prompt_tokens", u.PromptTokens)
+	addNonNegativeMetric(metrics, "completion_tokens", u.CompletionTokens)
+	addNonNegativeMetric(metrics, "tokens", u.TotalTokens)
 	if u.PromptTokenDetails.CachedTokens > 0 {
 		metrics["prompt_cached_tokens"] = int64(u.PromptTokenDetails.CachedTokens)
 	}
@@ -536,15 +933,9 @@ func modelTokenUsageToMetrics(u *model.TokenUsage) map[string]int64 {
 // non-streaming (model.TokenUsage) use different types with the same field layout.
 func schemaTokenUsageToMetrics(u *schema.TokenUsage) map[string]int64 {
 	metrics := make(map[string]int64)
-	if u.PromptTokens > 0 {
-		metrics["prompt_tokens"] = int64(u.PromptTokens)
-	}
-	if u.CompletionTokens > 0 {
-		metrics["completion_tokens"] = int64(u.CompletionTokens)
-	}
-	if u.TotalTokens > 0 {
-		metrics["tokens"] = int64(u.TotalTokens)
-	}
+	addNonNegativeMetric(metrics, "prompt_tokens", u.PromptTokens)
+	addNonNegativeMetric(metrics, "completion_tokens", u.CompletionTokens)
+	addNonNegativeMetric(metrics, "tokens", u.TotalTokens)
 	if u.PromptTokenDetails.CachedTokens > 0 {
 		metrics["prompt_cached_tokens"] = int64(u.PromptTokenDetails.CachedTokens)
 	}
@@ -555,47 +946,43 @@ func schemaTokenUsageToMetrics(u *schema.TokenUsage) map[string]int64 {
 }
 
 // buildEmbeddingMetadata constructs the braintrust.metadata map for embedding spans.
-func buildEmbeddingMetadata(info *callbacks.RunInfo, cfg *embedding.Config) map[string]any {
+func (h *Handler) buildEmbeddingMetadata(info *callbacks.RunInfo, cfg *embedding.Config) map[string]any {
 	metadata := map[string]any{
-		"provider": "cloudwego/eino",
+		"provider": h.providerFromInfo(info),
 	}
-	if info != nil && info.Type != "" {
-		metadata["provider"] = info.Type
-	}
-	if cfg != nil {
-		if cfg.Model != "" {
-			metadata["model"] = cfg.Model
-		}
-		if cfg.EncodingFormat != "" {
-			metadata["encoding_format"] = cfg.EncodingFormat
-		}
+	if cfg != nil && cfg.Model != "" {
+		metadata["model"] = cfg.Model
+	} else if h.opts.Model != "" {
+		metadata["model"] = h.opts.Model
 	}
 	return metadata
 }
 
-// embeddingOutputSummary mirrors the Python SDK convention for multi-input
-// embedding calls: {"embedding_length": N, "embeddings_count": M}.
+func embeddingInput(texts []string) map[string]any {
+	inputs := make([]map[string]any, len(texts))
+	for i, text := range texts {
+		inputs[i] = map[string]any{"content": text}
+	}
+	return map[string]any{"inputs": inputs}
+}
+
 func embeddingOutputSummary(embeddings [][]float64) map[string]any {
-	out := map[string]any{
-		"embeddings_count": len(embeddings),
-	}
-	if len(embeddings) > 0 {
-		out["embedding_length"] = len(embeddings[0])
-	}
-	return out
+	return map[string]any{"count": len(embeddings)}
 }
 
 // embeddingTokenUsageToMetrics converts embedding.TokenUsage into the standard
 // Braintrust metrics map. Embeddings have no completion tokens.
 func embeddingTokenUsageToMetrics(u *embedding.TokenUsage) map[string]int64 {
 	metrics := make(map[string]int64)
-	if u.PromptTokens > 0 {
-		metrics["prompt_tokens"] = int64(u.PromptTokens)
-	}
-	if u.TotalTokens > 0 {
-		metrics["tokens"] = int64(u.TotalTokens)
-	}
+	addNonNegativeMetric(metrics, "prompt_tokens", u.PromptTokens)
+	addNonNegativeMetric(metrics, "tokens", u.TotalTokens)
 	return metrics
+}
+
+func addNonNegativeMetric(metrics map[string]int64, name string, value int) {
+	if value >= 0 {
+		metrics[name] = int64(value)
+	}
 }
 
 // Compile-time assertion that Handler implements the required interfaces.

--- a/trace/contrib/cloudwego/eino/traceeino_test.go
+++ b/trace/contrib/cloudwego/eino/traceeino_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cloudwego/eino/components/embedding"
 	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/compose"
 	"github.com/cloudwego/eino/schema"
 
 	"github.com/braintrustdata/braintrust-sdk-go/internal/oteltest"
@@ -34,6 +35,18 @@ func makeRunInfo(name, typ string) *callbacks.RunInfo {
 func invokeChatModel(ctx context.Context, h *Handler, info *callbacks.RunInfo, input *model.CallbackInput, output *model.CallbackOutput) {
 	ctx = h.OnStart(ctx, info, input)
 	h.OnEnd(ctx, info, output)
+}
+
+func requireOutputMessage(t *testing.T, output any) (map[string]any, map[string]any) {
+	t.Helper()
+	choices, ok := output.([]any)
+	require.True(t, ok, "output should be an array of choices, got %T", output)
+	require.Len(t, choices, 1)
+	choice, ok := choices[0].(map[string]any)
+	require.True(t, ok)
+	message, ok := choice["message"].(map[string]any)
+	require.True(t, ok)
+	return choice, message
 }
 
 func TestOnStart(t *testing.T) {
@@ -106,10 +119,10 @@ func TestOnEnd_WithTokenUsage(t *testing.T) {
 
 	out := span.Output()
 	require.NotNil(t, out)
-	choice, ok := out.(map[string]interface{})
-	require.True(t, ok, "output should be a message object")
-	assert.Equal(t, "assistant", choice["role"])
-	assert.Equal(t, "Hello there!", choice["content"])
+	choice, message := requireOutputMessage(t, out)
+	assert.Equal(t, "stop", choice["finish_reason"])
+	assert.Equal(t, "assistant", message["role"])
+	assert.Equal(t, "Hello there!", message["content"])
 
 	metrics := span.Metrics()
 	require.NotNil(t, metrics)
@@ -183,9 +196,9 @@ func TestOnEndWithStreamOutput(t *testing.T) {
 
 	out := span.Output()
 	require.NotNil(t, out)
-	choice, ok := out.(map[string]interface{})
-	require.True(t, ok, "output should be a message object")
-	assert.Equal(t, "1 2 3", choice["content"])
+	choice, message := requireOutputMessage(t, out)
+	assert.Equal(t, "stop", choice["finish_reason"])
+	assert.Equal(t, "1 2 3", message["content"])
 
 	metrics := span.Metrics()
 	require.NotNil(t, metrics)
@@ -257,9 +270,8 @@ func TestOnStartWithStreamInput_ModelInput(t *testing.T) {
 
 	out := span.Output()
 	require.NotNil(t, out)
-	outMap, ok := out.(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "response", outMap["content"])
+	_, message := requireOutputMessage(t, out)
+	assert.Equal(t, "response", message["content"])
 
 	meta := span.Metadata()
 	require.NotNil(t, meta)
@@ -293,6 +305,66 @@ func TestOnStartWithStreamInput_ToolInput(t *testing.T) {
 	out := span.Output()
 	require.NotNil(t, out)
 	assert.Equal(t, "72F", out)
+}
+
+func TestOnStartWithStreamInput_TaskPreservesAllChunks(t *testing.T) {
+	tp, exporter := oteltest.Setup(t)
+	handler := NewHandlerWithOptions(HandlerOptions{TracerProvider: tp})
+	info := &callbacks.RunInfo{Component: compose.ComponentOfGraph}
+
+	sr, sw := schema.Pipe[callbacks.CallbackInput](3)
+	sw.Send(map[string]any{"chunk": 1}, nil)
+	sw.Send(map[string]any{"chunk": 2}, nil)
+	sw.Send(map[string]any{"chunk": 3}, nil)
+	sw.Close()
+
+	ctx := handler.OnStartWithStreamInput(context.Background(), info, sr)
+	handler.OnEnd(ctx, info, map[string]any{"done": true})
+
+	span := exporter.FlushOne()
+	inputs, ok := span.Input().([]any)
+	require.True(t, ok)
+	require.Len(t, inputs, 3)
+	assert.Equal(t, float64(1), inputs[0].(map[string]any)["chunk"])
+	assert.Equal(t, float64(3), inputs[2].(map[string]any)["chunk"])
+}
+
+func TestOnEndWithStreamOutput_TaskPreservesGenericChunks(t *testing.T) {
+	tp, exporter := oteltest.Setup(t)
+	handler := NewHandlerWithOptions(HandlerOptions{TracerProvider: tp})
+	info := &callbacks.RunInfo{Component: compose.ComponentOfGraph}
+	ctx := handler.OnStart(context.Background(), info, map[string]any{"input": true})
+
+	sr, sw := schema.Pipe[callbacks.CallbackOutput](2)
+	sw.Send(map[string]any{"chunk": 1}, nil)
+	sw.Send(map[string]any{"chunk": 2}, nil)
+	sw.Close()
+
+	handler.OnEndWithStreamOutput(ctx, info, sr)
+	handler.Wait()
+
+	span := exporter.FlushOne()
+	outputs, ok := span.Output().([]any)
+	require.True(t, ok)
+	require.Len(t, outputs, 2)
+	assert.Equal(t, float64(1), outputs[0].(map[string]any)["chunk"])
+	assert.Equal(t, float64(2), outputs[1].(map[string]any)["chunk"])
+}
+
+func TestOnEndWithStreamOutput_Tool(t *testing.T) {
+	tp, exporter := oteltest.Setup(t)
+	handler := NewHandlerWithOptions(HandlerOptions{TracerProvider: tp})
+	ctx := handler.OnStart(context.Background(), makeRunInfo("stream_tool", ""), &tool.CallbackInput{ArgumentsInJSON: `{}`})
+
+	sr, sw := schema.Pipe[callbacks.CallbackOutput](2)
+	sw.Send(&tool.CallbackOutput{Response: "hello "}, nil)
+	sw.Send(&tool.CallbackOutput{Response: "world"}, nil)
+	sw.Close()
+
+	handler.OnEndWithStreamOutput(ctx, nil, sr)
+	handler.Wait()
+	span := exporter.FlushOne()
+	assert.Equal(t, "hello world", span.Output())
 }
 
 func TestOnStartWithStreamInput_UnrecognizedInput(t *testing.T) {
@@ -334,6 +406,7 @@ func TestMetadata(t *testing.T) {
 	ctx := context.Background()
 	info := makeRunInfo("", "OpenAI")
 
+	toolChoice := schema.ToolChoiceForced
 	input := &model.CallbackInput{
 		Messages: []*schema.Message{{Role: schema.User, Content: "hi"}},
 		Config: &model.Config{
@@ -341,6 +414,14 @@ func TestMetadata(t *testing.T) {
 			MaxTokens:   100,
 			Temperature: 0.7,
 		},
+		Tools: []*schema.ToolInfo{{
+			Name: "get_weather",
+			Desc: "Get the current weather",
+			ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+				"location": {Type: schema.String, Desc: "City name", Required: true},
+			}),
+		}},
+		ToolChoice: &toolChoice,
 	}
 
 	ctx2 := handler.OnStart(ctx, info, input)
@@ -353,8 +434,19 @@ func TestMetadata(t *testing.T) {
 	meta := spans[0].Metadata()
 	require.NotNil(t, meta)
 	assert.Equal(t, "gpt-4o-mini", meta["model"])
-	// provider is derived from info.Type when available
-	assert.Equal(t, "OpenAI", meta["provider"])
+	// Provider and tool request controls are normalized for pricing and display.
+	assert.Equal(t, "openai", meta["provider"])
+	assert.Equal(t, "required", meta["tool_choice"])
+	tools, ok := meta["tools"].([]any)
+	require.True(t, ok)
+	require.Len(t, tools, 1)
+	toolDef := tools[0].(map[string]any)
+	assert.Equal(t, "function", toolDef["type"])
+	function := toolDef["function"].(map[string]any)
+	assert.Equal(t, "get_weather", function["name"])
+	parameters := function["parameters"].(map[string]any)
+	assert.Equal(t, "object", parameters["type"])
+	assert.Equal(t, []any{"location"}, parameters["required"])
 }
 
 func TestToolCallOutput(t *testing.T) {
@@ -394,6 +486,21 @@ func TestToolCallOutput(t *testing.T) {
 
 	inp := span.Input()
 	require.NotNil(t, inp)
+
+	choice, message := requireOutputMessage(t, span.Output())
+	assert.Equal(t, "tool_calls", choice["finish_reason"])
+	assert.Nil(t, message["content"])
+	toolCalls, ok := message["tool_calls"].([]any)
+	require.True(t, ok)
+	require.Len(t, toolCalls, 1)
+	toolCall, ok := toolCalls[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "call_abc123", toolCall["id"])
+	assert.Equal(t, "function", toolCall["type"])
+	function, ok := toolCall["function"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "get_weather", function["name"])
+	assert.Equal(t, `{"location":"New York"}`, function["arguments"])
 }
 
 func TestStreamError(t *testing.T) {
@@ -484,6 +591,50 @@ func TestToolOutputJSON_NotDoubleEncoded(t *testing.T) {
 	outMap, ok := out.(map[string]any)
 	require.True(t, ok, "expected parsed JSON object, got %T", out)
 	assert.Equal(t, float64(42), outMap["result"])
+}
+
+func TestToolEmptyAndMalformedJSONValues(t *testing.T) {
+	tp, exporter := oteltest.Setup(t)
+	handler := NewHandlerWithOptions(HandlerOptions{TracerProvider: tp})
+
+	ctx := handler.OnStart(context.Background(), makeRunInfo("tool", ""), &tool.CallbackInput{
+		ArgumentsInJSON: "not-json",
+	})
+	handler.OnEnd(ctx, nil, &tool.CallbackOutput{Response: ""})
+
+	span := exporter.FlushOne()
+	assert.Equal(t, "not-json", span.Input())
+	assert.Equal(t, "", span.Output())
+}
+
+func TestStructuredToolOutput(t *testing.T) {
+	tp, exporter := oteltest.Setup(t)
+	handler := NewHandlerWithOptions(HandlerOptions{TracerProvider: tp})
+	imageData := "aW1hZ2U="
+
+	ctx := handler.OnStart(context.Background(), makeRunInfo("tool", ""), &tool.CallbackInput{ArgumentsInJSON: `{}`})
+	handler.OnEnd(ctx, nil, &tool.CallbackOutput{ToolOutput: &schema.ToolResult{Parts: []schema.ToolOutputPart{
+		{Type: schema.ToolPartTypeText, Text: "result"},
+		{Type: schema.ToolPartTypeImage, Image: &schema.ToolOutputImage{MessagePartCommon: schema.MessagePartCommon{
+			Base64Data: &imageData,
+			MIMEType:   "image/png",
+		}}},
+	}}})
+
+	span := exporter.FlushOne()
+	output := span.Output().(map[string]any)
+	parts := output["parts"].([]any)
+	require.Len(t, parts, 2)
+	assert.Equal(t, "result", parts[0].(map[string]any)["text"])
+	imageURL := parts[1].(map[string]any)["image_url"].(map[string]any)
+	assert.Equal(t, "data:image/png;base64,aW1hZ2U=", imageURL["url"])
+}
+
+func TestStructuredToolOutputRejectsMalformedParts(t *testing.T) {
+	_, err := convertToolResult(&schema.ToolResult{Parts: []schema.ToolOutputPart{{
+		Type: schema.ToolPartTypeImage,
+	}}})
+	require.Error(t, err)
 }
 
 func TestToolOutputPlainString(t *testing.T) {
@@ -779,22 +930,24 @@ func TestEmbeddingCallback(t *testing.T) {
 
 	inp := span.Input()
 	require.NotNil(t, inp)
-	texts, ok := inp.([]interface{})
-	require.True(t, ok, "input should be array of texts")
-	require.Len(t, texts, 2)
-	assert.Equal(t, "hello world", texts[0])
-	assert.Equal(t, "braintrust tracing", texts[1])
+	inputMap, ok := inp.(map[string]any)
+	require.True(t, ok)
+	inputs, ok := inputMap["inputs"].([]any)
+	require.True(t, ok)
+	require.Len(t, inputs, 2)
+	assert.Equal(t, "hello world", inputs[0].(map[string]any)["content"])
+	assert.Equal(t, "braintrust tracing", inputs[1].(map[string]any)["content"])
 
 	out := span.Output()
 	outMap, ok := out.(map[string]interface{})
 	require.True(t, ok)
-	assert.Equal(t, float64(3), outMap["embedding_length"])
-	assert.Equal(t, float64(2), outMap["embeddings_count"])
+	assert.Equal(t, float64(2), outMap["count"])
+	assert.NotContains(t, outMap, "embedding_length")
 
 	metadata := span.Metadata()
-	assert.Equal(t, "OpenAI", metadata["provider"])
+	assert.Equal(t, "openai", metadata["provider"])
 	assert.Equal(t, "text-embedding-3-small", metadata["model"])
-	assert.Equal(t, "float", metadata["encoding_format"])
+	assert.NotContains(t, metadata, "encoding_format")
 
 	metrics := span.Metrics()
 	assert.Equal(t, float64(5), metrics["prompt_tokens"])
@@ -812,12 +965,12 @@ func TestEmbeddingOutputSummary(t *testing.T) {
 		{
 			name: "non-empty",
 			in:   [][]float64{{0.1, 0.2, 0.3}, {0.4, 0.5, 0.6}},
-			want: map[string]any{"embedding_length": 3, "embeddings_count": 2},
+			want: map[string]any{"count": 2},
 		},
 		{
 			name: "empty",
 			in:   nil,
-			want: map[string]any{"embeddings_count": 0},
+			want: map[string]any{"count": 0},
 		},
 	}
 	for _, tc := range cases {
@@ -836,4 +989,72 @@ func TestEmbeddingTokenUsageToMetrics(t *testing.T) {
 	assert.Equal(t, int64(7), m["tokens"])
 	_, hasCompletion := m["completion_tokens"]
 	assert.False(t, hasCompletion)
+}
+
+func TestMetricsIncludeReportedZeroAndOmitNegativeValues(t *testing.T) {
+	metrics := modelTokenUsageToMetrics(&model.TokenUsage{
+		PromptTokens:     0,
+		CompletionTokens: -1,
+		TotalTokens:      0,
+	})
+	assert.Equal(t, int64(0), metrics["prompt_tokens"])
+	assert.Equal(t, int64(0), metrics["tokens"])
+	assert.NotContains(t, metrics, "completion_tokens")
+}
+
+func TestHandlerMetadataOverrides(t *testing.T) {
+	handler := NewHandlerWithOptions(HandlerOptions{
+		Provider: "Azure",
+		Model:    "deployment-name",
+	})
+	metadata := handler.buildMetadata(makeRunInfo("", "OpenAI"), &model.CallbackInput{})
+	assert.Equal(t, "azure", metadata["provider"])
+	assert.Equal(t, "deployment-name", metadata["model"])
+}
+
+func TestMultimodalInputUsesCanonicalContentParts(t *testing.T) {
+	imageData := "aW1hZ2U="
+	message := convertMessage(&schema.Message{
+		Role: schema.User,
+		UserInputMultiContent: []schema.MessageInputPart{
+			{Type: schema.ChatMessagePartTypeText, Text: "describe this"},
+			{
+				Type: schema.ChatMessagePartTypeImageURL,
+				Image: &schema.MessageInputImage{MessagePartCommon: schema.MessagePartCommon{
+					Base64Data: &imageData,
+					MIMEType:   "image/png",
+				}},
+			},
+		},
+	})
+
+	parts, ok := message["content"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, parts, 2)
+	assert.Equal(t, map[string]any{"type": "text", "text": "describe this"}, parts[0])
+	imageURL := parts[1]["image_url"].(map[string]any)
+	assert.Equal(t, "data:image/png;base64,aW1hZ2U=", imageURL["url"])
+}
+
+func TestMultimodalOutputPreservesReasoning(t *testing.T) {
+	parts := convertOutputParts([]schema.MessageOutputPart{{
+		Type: schema.ChatMessagePartTypeReasoning,
+		Reasoning: &schema.MessageOutputReasoning{
+			Text:      "reasoning summary",
+			Signature: "signature",
+		},
+	}})
+
+	require.Len(t, parts, 1)
+	assert.Equal(t, map[string]any{
+		"type":      "reasoning",
+		"text":      "reasoning summary",
+		"signature": "signature",
+	}, parts[0])
+}
+
+func TestNormalizeFinishReason(t *testing.T) {
+	assert.Equal(t, "tool_calls", normalizeFinishReason("tool_use", true))
+	assert.Equal(t, "length", normalizeFinishReason("max_tokens", false))
+	assert.Equal(t, "stop", normalizeFinishReason("end_turn", false))
 }


### PR DESCRIPTION
Aligns the eino instrumentation with https://github.com/braintrustdata/braintrust-spec/blob/main/skills/instrumentation-spec

### AI Summary

- emit canonical OpenAI-style chat messages, choices, finish reasons, and tool calls
- capture available tool definitions and normalized tool-choice controls in metadata
- represent Eino graphs as task spans with ordered child LLM and tool spans
- aggregate streaming output and report time-to-first-token and canonical token metrics
- emit canonical embedding inputs and count-only outputs without logging raw vectors
- normalize multimodal and reasoning content while preserving attachment processing
- attribute model usage with normalized provider/model metadata and explicit allowlists
- validate structured tool results and preserve tool inputs, outputs, and errors

Specification references:

- Instrumentation guide: https://github.com/braintrustdata/braintrust-spec/blob/main/skills/instrumentation-spec/references/instrumentation-guide.md
- Embedding APIs: https://github.com/braintrustdata/braintrust-spec/blob/main/skills/instrumentation-spec/references/features/embeddings.md
- Token and cost metrics: https://github.com/braintrustdata/braintrust-spec/blob/main/skills/instrumentation-spec/references/features/token-and-cost-metrics.md
- Attachments: https://github.com/braintrustdata/braintrust-spec/blob/main/skills/instrumentation-spec/references/features/attachments.md